### PR TITLE
Feature/#6 mypage achievement _ 기본 UI 및 데이터 연동

### DIFF
--- a/src/app/(auth)/mypage/achievement/page.tsx
+++ b/src/app/(auth)/mypage/achievement/page.tsx
@@ -1,8 +1,66 @@
-const AchievementPage = () => {
+import MypageProgressBar from '@/components/features/mypage/mypage-progressbar';
+import { getUserMetadata } from '@/lib/utils/api/auth-action';
+import { getUserMission, getUserMissionLevels } from '@/lib/utils/api/my-mission.api';
+import { calculateUserLevel } from '@/lib/utils/calculate-user-level';
+
+const AchievementPage = async () => {
+  //유저 전체 레벨 계산 로직 -> progressBar 에 Props 전달
+  const user = await getUserMetadata();
+  const missions = await getUserMission();
+  const totalCount = [...missions].length;
+  const userLevel = calculateUserLevel(totalCount);
+
+  //유저 미션 레벨 조회 : 5개 (혼밥,혼자여행,갓생,혼놀,청소)
+  const userMissionLevels = await getUserMissionLevels();
+
+  //레벨 표기 _ (Lv.1,Lv.2,Lv.3,Lv.4,Lv.5,master)
+  const formatLevel = (level: string) => (level === 'master' ? 'master' : `Lv.${level}`);
+
+  /// 미션 카테고리 목록 _ description은 추후 수정 예정
+  const categories = [
+    { name: '혼밥', level: userMissionLevels.meal, description: '혼자서 밥 먹기 미션을 수행해보세요!' },
+    { name: '혼자여행', level: userMissionLevels.travel, description: '혼자 여행을 떠나는 도전을 해보세요!' },
+    { name: '갓생', level: userMissionLevels.goat, description: '자기 계발과 성장에 집중하는 라이프 스타일!' },
+    { name: '혼놀', level: userMissionLevels.play, description: '혼자서도 재미있게 노는 방법을 찾아보세요!' },
+    { name: '청소', level: userMissionLevels.clean, description: '청소 습관을 만들고 깔끔한 공간을 유지하세요!' }
+  ];
+
   return (
-    <div>
-      <strong>OOO♥️님의 달성도 현황</strong>
-      <p>여기에서 나의 달성도 현황을 확인할 수 있습니다!</p>
+    <div className="flex flex-col gap-3">
+      {/* 전체 레벨 5단계 */}
+      <strong>{user?.nickname}님의 혼자 라이프 레벨</strong>
+      <MypageProgressBar level={userLevel} />
+
+      {/* 각각의 미션 카테고리 level 현황 */}
+      <strong>{user?.nickname}님의 체크리스트 달성도</strong>
+      <section className="flex gap-3 rounded-md border border-slate-200 p-3">
+        {categories.map(({ name, level, description }) => (
+          <div
+            key={name}
+            className="group relative flex flex-col items-center justify-center rounded-md p-3 transition-colors duration-200 hover:bg-gray-200"
+          >
+            {/* 카테고리명 */}
+            <div className="cursor-pointer">{name}</div>
+            {/* 레벨 표시 */}
+            <div>{formatLevel(level)}</div>
+            <div className="text-orange-500">1/5</div>
+            {/* Hover 시 나타나는 툴팁 */}
+            <div className="absolute -bottom-14 hidden w-48 rounded-md bg-orange-600 p-2 text-sm text-white shadow-lg group-hover:block">
+              {description}
+            </div>
+          </div>
+        ))}
+      </section>
+
+      {/* 렌덤 미션 뽑기 _ 모달 설치 필요 */}
+      <div className="flex justify-between">
+        <strong>오늘의 랜덤 미션</strong>
+        <button>미션 받으러 가기</button>
+      </div>
+      <section className="bg-slate-200 p-3">
+        <p>아직 랜덤 미션을 받지 않았어요. 랜덤 미션을 받으러 가볼까요?</p>
+        <p>랜덤 미션은 포인트가 두배에요!</p>
+      </section>
     </div>
   );
 };

--- a/src/components/features/mypage/mypage-progressbar.tsx
+++ b/src/components/features/mypage/mypage-progressbar.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { USER_LEVELS } from '@/lib/utils/calculate-user-level';
+import { useEffect, useState } from 'react';
+
+type MypageProgressBarProps = {
+  level: string;
+};
+const MypageProgressBar = ({ level }: MypageProgressBarProps) => {
+  //progress bar 시작위치 : 초기값 0
+  const [currentStep, setCurrentStep] = useState(0);
+
+  // level에 따른 currentStep 할당
+  useEffect(() => {
+    switch (level) {
+      case USER_LEVELS.START:
+        setCurrentStep(0);
+        break;
+      case USER_LEVELS.BEGINNER:
+        setCurrentStep(1);
+        break;
+      case USER_LEVELS.NOVICE:
+        setCurrentStep(2);
+        break;
+      case USER_LEVELS.INTERMEDIATE:
+        setCurrentStep(3);
+        break;
+      case USER_LEVELS.EXPERT:
+        setCurrentStep(4);
+        break;
+      case USER_LEVELS.MASTER:
+        setCurrentStep(5);
+        break;
+      default:
+        setCurrentStep(0);
+    }
+  }, [level]);
+
+  // 진행 상태에 맞는 색상 채우기
+  const progressWidth = `${(currentStep / 5) * 100}%`;
+
+  return (
+    <div className="mx-auto w-full max-w-lg">
+      <div className="relative flex items-center justify-between">
+        {/* 레벨 현황 bar*/}
+        <div className="relative h-2 w-full rounded-md bg-gray-300">
+          <div className="absolute left-0 top-0 h-full rounded-md bg-orange-500" style={{ width: progressWidth }}></div>
+        </div>
+      </div>
+
+      {/* 유저 레벨 라벨 */}
+      <div className="mt-2 flex justify-between">
+        {LEVEL_NAME.map((level) => (
+          <span key={level} className="text-sm">
+            {level}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MypageProgressBar;
+
+const LEVEL_NAME = ['', '입문', '초보', '중수', '고수', '마스터'];

--- a/src/components/features/mypage/mypage-progressbar.tsx
+++ b/src/components/features/mypage/mypage-progressbar.tsx
@@ -8,32 +8,21 @@ type MypageProgressBarProps = {
 };
 const MypageProgressBar = ({ level }: MypageProgressBarProps) => {
   //progress bar 시작위치 : 초기값 0
-  const [currentStep, setCurrentStep] = useState(0);
+  const [currentStep, setCurrentStep] = useState<number>(0);
 
-  // level에 따른 currentStep 할당
+  const levelStepMap = {
+    [USER_LEVELS.START]: 0,
+    [USER_LEVELS.BEGINNER]: 1,
+    [USER_LEVELS.NOVICE]: 2,
+    [USER_LEVELS.INTERMEDIATE]: 3,
+    [USER_LEVELS.EXPERT]: 4,
+    [USER_LEVELS.MASTER]: 5
+  } as const;
+
+  type LevelKey = keyof typeof levelStepMap;
+
   useEffect(() => {
-    switch (level) {
-      case USER_LEVELS.START:
-        setCurrentStep(0);
-        break;
-      case USER_LEVELS.BEGINNER:
-        setCurrentStep(1);
-        break;
-      case USER_LEVELS.NOVICE:
-        setCurrentStep(2);
-        break;
-      case USER_LEVELS.INTERMEDIATE:
-        setCurrentStep(3);
-        break;
-      case USER_LEVELS.EXPERT:
-        setCurrentStep(4);
-        break;
-      case USER_LEVELS.MASTER:
-        setCurrentStep(5);
-        break;
-      default:
-        setCurrentStep(0);
-    }
+    setCurrentStep(levelStepMap[level as LevelKey] ?? 0);
   }, [level]);
 
   // 진행 상태에 맞는 색상 채우기
@@ -50,7 +39,7 @@ const MypageProgressBar = ({ level }: MypageProgressBarProps) => {
 
       {/* 유저 레벨 라벨 */}
       <div className="mt-2 flex justify-between">
-        {LEVEL_NAME.map((level) => (
+        {Object.values(USER_LEVELS).map((level) => (
           <span key={level} className="text-sm">
             {level}
           </span>
@@ -61,5 +50,3 @@ const MypageProgressBar = ({ level }: MypageProgressBarProps) => {
 };
 
 export default MypageProgressBar;
-
-const LEVEL_NAME = ['', '입문', '초보', '중수', '고수', '마스터'];

--- a/src/lib/utils/api/my-mission.api.ts
+++ b/src/lib/utils/api/my-mission.api.ts
@@ -1,0 +1,54 @@
+import { createClient } from '@/lib/utils/supabase/supabase-server';
+
+/**
+ * Supabase에서 `user_mission` 테이블의 `로그인 한 User`가 달성한 미션 전부를 조회하는 함수
+ *
+ * @function getUserMissionById
+ * @returns  id, created_at, user_id, completed_id, mission_list: {type, level}
+ * @throws {Error} 데이터베이스 작업 중 오류가 발생하면 예외를 던집니다.
+ */
+export const getUserMission = async () => {
+  const supabase = await createClient();
+  //로그인한 유저 id 조회 (임시용)
+  const {
+    data: { user },
+    error: userError
+  } = await supabase.auth.getUser();
+  if (!user) throw userError;
+
+  // 로그인한 유저의 완료 미션과, mission_list 테이블에서 id와 type을 조인하여 조회
+  const { data: UserMissions, error } = await supabase
+    .from('user_mission')
+    .select(`*,mission_list(type, level)`)
+    .eq('user_id', user.id);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+  return UserMissions;
+};
+
+/**
+ * Supabase에서 `user_level` 테이블의 카테고리별 레벨 조회하는 함수
+ *
+ * @function getUserMissionLevels
+ * @returns  id, user_id, meal, play, travel, clean, goat
+ * @throws {Error} 데이터베이스 작업 중 오류가 발생하면 예외를 던집니다.
+ */
+export const getUserMissionLevels = async () => {
+  const supabase = await createClient();
+  //로그인한 유저 id 조회 (임시용)
+  const {
+    data: { user },
+    error: userError
+  } = await supabase.auth.getUser();
+  if (!user) throw userError;
+
+  // 로그인한 유저의 레벨 조회
+  const { data: UserMissionsLevels, error } = await supabase.from('user_level').select('*').eq('user_id', user.id);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+  return UserMissionsLevels[0];
+};

--- a/src/lib/utils/api/my-mission.api.ts
+++ b/src/lib/utils/api/my-mission.api.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/utils/supabase/supabase-server';
+import { getUserId } from './auth-action';
 
 /**
  * Supabase에서 `user_mission` 테이블의 `로그인 한 User`가 달성한 미션 전부를 조회하는 함수
@@ -9,18 +10,15 @@ import { createClient } from '@/lib/utils/supabase/supabase-server';
  */
 export const getUserMission = async () => {
   const supabase = await createClient();
-  //로그인한 유저 id 조회 (임시용)
-  const {
-    data: { user },
-    error: userError
-  } = await supabase.auth.getUser();
-  if (!user) throw userError;
+  //로그인한 유저 id 조회
+  const userId = await getUserId();
+  if (!userId) throw new Error('로그인 한 유저의 아이디가 존재하지 않습니다');
 
   // 로그인한 유저의 완료 미션과, mission_list 테이블에서 id와 type을 조인하여 조회
   const { data: UserMissions, error } = await supabase
     .from('user_mission')
     .select(`*,mission_list(type, level)`)
-    .eq('user_id', user.id);
+    .eq('user_id', userId);
 
   if (error) throw new Error(error.message);
   return UserMissions;
@@ -35,15 +33,12 @@ export const getUserMission = async () => {
  */
 export const getUserMissionLevels = async () => {
   const supabase = await createClient();
-  //로그인한 유저 id 조회 (임시용)
-  const {
-    data: { user },
-    error: userError
-  } = await supabase.auth.getUser();
-  if (!user) throw userError;
+  //로그인한 유저 id 조회
+  const userId = await getUserId();
+  if (!userId) throw new Error('로그인 한 유저의 아이디가 존재하지 않습니다');
 
   // 로그인한 유저의 레벨 조회
-  const { data: UserMissionsLevels, error } = await supabase.from('user_level').select('*').eq('user_id', user.id);
+  const { data: UserMissionsLevels, error } = await supabase.from('user_level').select('*').eq('user_id', userId);
 
   if (error) throw new Error(error.message);
   return UserMissionsLevels[0];

--- a/src/lib/utils/api/my-mission.api.ts
+++ b/src/lib/utils/api/my-mission.api.ts
@@ -22,9 +22,7 @@ export const getUserMission = async () => {
     .select(`*,mission_list(type, level)`)
     .eq('user_id', user.id);
 
-  if (error) {
-    throw new Error(error.message);
-  }
+  if (error) throw new Error(error.message);
   return UserMissions;
 };
 
@@ -47,8 +45,6 @@ export const getUserMissionLevels = async () => {
   // 로그인한 유저의 레벨 조회
   const { data: UserMissionsLevels, error } = await supabase.from('user_level').select('*').eq('user_id', user.id);
 
-  if (error) {
-    throw new Error(error.message);
-  }
+  if (error) throw new Error(error.message);
   return UserMissionsLevels[0];
 };

--- a/src/lib/utils/calculate-user-level.ts
+++ b/src/lib/utils/calculate-user-level.ts
@@ -1,0 +1,33 @@
+/**
+ *
+ * @function calculateUserLevel - 유저의 전체 레벨 단계를 판별하는 함수
+ * @param totalCount - 유저가 달성한 전체 미션 개수 (number)
+ * @returns - 시작 단계, 입문 단계, 초보 단계, 중수 단계, 고수 단계, 마스터 단계
+ */
+export const calculateUserLevel = (totalCount: number): string => {
+  switch (true) {
+    case totalCount >= 0 && totalCount < 25:
+      return USER_LEVELS.START;
+    case totalCount >= 25 && totalCount < 50:
+      return USER_LEVELS.BEGINNER;
+    case totalCount >= 50 && totalCount < 75:
+      return USER_LEVELS.NOVICE;
+    case totalCount >= 75 && totalCount < 100:
+      return USER_LEVELS.INTERMEDIATE;
+    case totalCount >= 100 && totalCount < 125:
+      return USER_LEVELS.EXPERT;
+    case totalCount >= 125:
+      return USER_LEVELS.MASTER;
+    default:
+      return '알 수 없음'; // 예외 처리
+  }
+};
+
+export const USER_LEVELS = {
+  START: '시작 단계',
+  BEGINNER: '입문 단계',
+  NOVICE: '초보 단계',
+  INTERMEDIATE: '중수 단계',
+  EXPERT: '고수 단계',
+  MASTER: '마스터 단계'
+} as const;

--- a/src/lib/utils/calculate-user-level.ts
+++ b/src/lib/utils/calculate-user-level.ts
@@ -5,29 +5,20 @@
  * @returns - 시작 단계, 입문 단계, 초보 단계, 중수 단계, 고수 단계, 마스터 단계
  */
 export const calculateUserLevel = (totalCount: number): string => {
-  switch (true) {
-    case totalCount >= 0 && totalCount < 25:
-      return USER_LEVELS.START;
-    case totalCount >= 25 && totalCount < 50:
-      return USER_LEVELS.BEGINNER;
-    case totalCount >= 50 && totalCount < 75:
-      return USER_LEVELS.NOVICE;
-    case totalCount >= 75 && totalCount < 100:
-      return USER_LEVELS.INTERMEDIATE;
-    case totalCount >= 100 && totalCount < 125:
-      return USER_LEVELS.EXPERT;
-    case totalCount >= 125:
-      return USER_LEVELS.MASTER;
-    default:
-      return '알 수 없음'; // 예외 처리
-  }
+  if (totalCount >= 125) return USER_LEVELS.MASTER;
+  if (totalCount >= 100) return USER_LEVELS.EXPERT;
+  if (totalCount >= 75) return USER_LEVELS.INTERMEDIATE;
+  if (totalCount >= 50) return USER_LEVELS.NOVICE;
+  if (totalCount >= 25) return USER_LEVELS.BEGINNER;
+  if (totalCount >= 0) return USER_LEVELS.START;
+  return '알 수 없음';
 };
 
 export const USER_LEVELS = {
-  START: '시작 단계',
-  BEGINNER: '입문 단계',
-  NOVICE: '초보 단계',
-  INTERMEDIATE: '중수 단계',
-  EXPERT: '고수 단계',
-  MASTER: '마스터 단계'
+  START: '',
+  BEGINNER: '입문',
+  NOVICE: '초보',
+  INTERMEDIATE: '중수',
+  EXPERT: '고수',
+  MASTER: '마스터'
 } as const;


### PR DESCRIPTION
## ✨ feature(#이슈번호): 기능명
 - close #6 

 
 ## 🔎 작업 내용
 
 - 나의 달성도 progress bar _ 임의로 했는데 추후 디자인에 따라 UI라이브러리로 적용할 수도 있을 것 같습니다.
 - 유저 전체레벨 계산 로직
 - 수파베이스 데이터 연동 (user_level 에서 카테고리별 레벨 조회 및 전체미션 조회)
 
 ## 🖼️ 작업 내용 미리보기
 
![chrome-capture-2025-4-4 (3)](https://github.com/user-attachments/assets/90a0da48-1ab8-4d9c-9d3a-8a9ee44650a8)


 ## 💬 리뷰 요구사항
 
 1. 미션별 레벨 현황에 1/5, 4/5 이런식으로 표시해주면, 한눈에 1개 남았구나! 4개 남았구나!를 알 수 있을 것 같아서 임시로 넣어봤습니다.
   추후 디자인 정해지면, 수정 반영하겠습니다
2. 랜덤 미션 뽑기는 모달 설치가 필요합니다. (작업 안되어 있음)

 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 
- clo #6 