### PR TITLE
Feature/#44 마이페이지 (혼자라이프) 무한스크롤 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-day-picker": "8.10.1",
     "react-dom": "^18",
     "react-hook-form": "^7.54.2",
+    "react-intersection-observer": "^9.16.0",
     "swiper": "^11.2.6",
     "tailwind-merge": "^3.1.0",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@18.3.1)
+      react-intersection-observer:
+        specifier: ^9.16.0
+        version: 9.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       swiper:
         specifier: ^11.2.6
         version: 11.2.6
@@ -2140,6 +2143,15 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-intersection-observer@9.16.0:
+    resolution: {integrity: sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4703,6 +4715,12 @@ snapshots:
   react-hook-form@7.54.2(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  react-intersection-observer@9.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react-is@16.13.1: {}
 

--- a/src/app/(auth)/mypage/my-life-list/page.tsx
+++ b/src/app/(auth)/mypage/my-life-list/page.tsx
@@ -1,18 +1,13 @@
-import { getAllLifePostsById } from '@/lib/utils/api/my-life.api';
-import LifePostCard from '@/components/common/life-post-card';
+import MyLifeListClient from '@/components/features/mypage/my-life-list-client';
+import { getUserProfile } from '@/lib/utils/api/auth-action';
 
 const MyLifeListPage = async () => {
-  // 해당 User의 작성 게시글 전체 조회 (기본 최신순 _ 추후 페이지네이션 or 무한스크롤 작업 예정)
-  const myAllLifePosts = await getAllLifePostsById();
+  const profile = await getUserProfile();
 
   return (
     <div>
-      <strong>OOO♥️님의 혼자 라이프 기록</strong>
-      <section className="grid items-center justify-center gap-3 md:grid-cols-2 lg:grid-cols-4">
-        {myAllLifePosts.map((post) => (
-          <LifePostCard key={post.id} lifePost={post} />
-        ))}
-      </section>
+      <strong>{profile?.nickname}님의 혼자 라이프 기록</strong>
+      <MyLifeListClient />
     </div>
   );
 };

--- a/src/components/features/mypage/my-life-list-client.tsx
+++ b/src/components/features/mypage/my-life-list-client.tsx
@@ -5,6 +5,7 @@ import { useInView } from 'react-intersection-observer';
 import SoloLifeCard from '@/components/common/solo-life-card';
 import useGetLifePostsInfiniteQuery from '@/lib/hooks/queries/use-get-life-posts-infinite-query';
 import type { GetLifePostsResponse, SoloLifeCardType } from '@/types/life-post';
+import { DEFAULT_LIFE_IMAGE_URL } from '@/constants/default-image-url';
 
 const MyLifeListClient = () => {
   const {
@@ -37,7 +38,7 @@ const MyLifeListClient = () => {
           date: post.date,
           title: post.title || post.content.split('\n')[0] || '제목 없음',
           content: post.content,
-          thumbnail: imageUrls[0] || DEFAULT_IMAGE_URL,
+          thumbnail: imageUrls[0] || DEFAULT_LIFE_IMAGE_URL,
           imageUrls,
           isMission: post.mission_id !== null,
           tags: post.tags ?? []
@@ -68,5 +69,3 @@ const MyLifeListClient = () => {
 };
 
 export default MyLifeListClient;
-
-const DEFAULT_IMAGE_URL = '/images/default-image.svg';

--- a/src/components/features/mypage/my-life-list-client.tsx
+++ b/src/components/features/mypage/my-life-list-client.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+import SoloLifeCard from '@/components/common/solo-life-card';
+import useGetLifePostsInfiniteQuery from '@/lib/hooks/queries/use-get-life-posts-infinite-query';
+import type { GetLifePostsResponse, SoloLifeCardType } from '@/types/life-post';
+
+const MyLifeListClient = () => {
+  const {
+    data: posts,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
+  } = useGetLifePostsInfiniteQuery();
+
+  console.log(posts);
+
+  const { ref, inView } = useInView({
+    threshold: 0.5
+  });
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView]);
+
+  const parsedList: SoloLifeCardType[] =
+    posts?.pages?.flatMap((page: GetLifePostsResponse) =>
+      page.data.map((post) => {
+        const imageUrls = post.image_urls ?? [];
+        return {
+          id: post.id.toString(),
+          date: post.date,
+          title: post.title || post.content.split('\n')[0] || '제목 없음',
+          content: post.content,
+          thumbnail: imageUrls[0] || '/images/default-image.svg',
+          imageUrls,
+          isMission: post.mission_id !== null,
+          tags: post.tags ?? []
+        };
+      })
+    ) ?? [];
+
+  if (isLoading) return <div className="p-4">로딩 중...</div>;
+  if (error) return <div className="p-4 text-red-500">에러 발생</div>;
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
+      {parsedList.length === 0 ? (
+        <div className="col-span-full text-center text-gray-500">이 날 작성된 혼자 라이프가 없어요.</div>
+      ) : (
+        parsedList.map((post) => <SoloLifeCard key={post.id} {...post} />)
+      )}
+      {/* 무한 스크롤 로딩 및 종료 메세지 */}
+      <div className="col-span-full flex items-center justify-center py-4 text-sm text-slate-400">
+        {hasNextPage ? (
+          <div ref={ref}>{isFetchingNextPage && '불러오는 중...'}</div>
+        ) : (
+          '작성하신 라이프글을 전부 불러왔어요.'
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MyLifeListClient;

--- a/src/components/features/mypage/my-life-list-client.tsx
+++ b/src/components/features/mypage/my-life-list-client.tsx
@@ -9,7 +9,7 @@ import type { GetLifePostsResponse, SoloLifeCardType } from '@/types/life-post';
 const MyLifeListClient = () => {
   const {
     data: posts,
-    isLoading,
+    isPending,
     error,
     fetchNextPage,
     hasNextPage,
@@ -37,7 +37,7 @@ const MyLifeListClient = () => {
           date: post.date,
           title: post.title || post.content.split('\n')[0] || '제목 없음',
           content: post.content,
-          thumbnail: imageUrls[0] || '/images/default-image.svg',
+          thumbnail: imageUrls[0] || DEFAULT_IMAGE_URL,
           imageUrls,
           isMission: post.mission_id !== null,
           tags: post.tags ?? []
@@ -45,7 +45,7 @@ const MyLifeListClient = () => {
       })
     ) ?? [];
 
-  if (isLoading) return <div className="p-4">로딩 중...</div>;
+  if (isPending) return <div className="p-4">로딩 중...</div>;
   if (error) return <div className="p-4 text-red-500">에러 발생</div>;
 
   return (
@@ -68,3 +68,5 @@ const MyLifeListClient = () => {
 };
 
 export default MyLifeListClient;
+
+const DEFAULT_IMAGE_URL = '/images/default-image.svg';

--- a/src/constants/default-image-url.ts
+++ b/src/constants/default-image-url.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_LIFE_IMAGE_URL = '/images/default-image.svg';

--- a/src/constants/query-keys.ts
+++ b/src/constants/query-keys.ts
@@ -1,3 +1,4 @@
 export const QUERY_KEY = {
-  PROFILE: ['profile']
+  PROFILE: ['profile'],
+  LIFE_POSTS_INFINITE: ['life-posts-infinite']
 };

--- a/src/lib/hooks/queries/use-get-life-posts-infinite-query.ts
+++ b/src/lib/hooks/queries/use-get-life-posts-infinite-query.ts
@@ -1,6 +1,7 @@
 import { getLifePostsAll } from '@/lib/utils/api/my-life-client.api';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import type { GetLifePostsResponse } from '@/types/life-post';
+import { QUERY_KEY } from '@/constants/query-keys';
 
 /**
  * @function useGetLifePostsInfiniteQuery
@@ -8,7 +9,7 @@ import type { GetLifePostsResponse } from '@/types/life-post';
  */
 const useGetLifePostsInfiniteQuery = () => {
   return useInfiniteQuery<GetLifePostsResponse>({
-    queryKey: ['life-posts-infinite'],
+    queryKey: QUERY_KEY.LIFE_POSTS_INFINITE,
     queryFn: ({ pageParam }) => getLifePostsAll({ page: pageParam as number }),
     getNextPageParam: (lastPage) => {
       if (lastPage.page < lastPage.totalPages) {

--- a/src/lib/hooks/queries/use-get-life-posts-infinite-query.ts
+++ b/src/lib/hooks/queries/use-get-life-posts-infinite-query.ts
@@ -1,0 +1,23 @@
+import { getLifePostsAll } from '@/lib/utils/api/my-life-client.api';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import type { GetLifePostsResponse } from '@/types/life-post';
+
+/**
+ * @function useGetLifePostsInfiniteQuery
+ * @returns - pageParams, pages 을 반환,
+ */
+const useGetLifePostsInfiniteQuery = () => {
+  return useInfiniteQuery<GetLifePostsResponse>({
+    queryKey: ['life-posts-infinite'],
+    queryFn: ({ pageParam }) => getLifePostsAll({ page: pageParam as number }),
+    getNextPageParam: (lastPage) => {
+      if (lastPage.page < lastPage.totalPages) {
+        return lastPage.page + 1;
+      }
+      return undefined;
+    },
+    initialPageParam: 1
+  });
+};
+
+export default useGetLifePostsInfiniteQuery;

--- a/src/lib/utils/api/my-life-client.api.ts
+++ b/src/lib/utils/api/my-life-client.api.ts
@@ -1,0 +1,42 @@
+import { TABLE } from '@/constants/supabase-tables-name';
+import { supabase } from '@/lib/utils/supabase/supabase-client';
+import { getUserSessionState } from '@/lib/utils/api/auth-action';
+import type { GetLifePostsResponse } from '@/types/life-post';
+
+//무한스크롤 API
+export const getLifePostsAll = async ({ page }: { page: number }): Promise<GetLifePostsResponse> => {
+  const { userId } = await getUserSessionState();
+  if (!userId) throw new Error();
+
+  // 페이지당 게시물 수
+  const postsPerPage = 8;
+  const from = (page - 1) * postsPerPage;
+  const to = from + postsPerPage - 1;
+
+  const {
+    data: MyLifePosts,
+    error,
+    count
+  } = await supabase
+    .from(TABLE.LIFE_POSTS)
+    .select(`*,life_post_image_path(image_url)`, { count: 'exact' })
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .order('id', { ascending: false })
+    .range(from, to);
+
+  if (error) throw new Error(error.message);
+
+  const totalPages = count ? Math.ceil(count / postsPerPage) : 1;
+
+  const processed = (MyLifePosts ?? []).map((post: any) => ({
+    ...post,
+    image_urls: post.life_post_image_path?.map((img: any) => img.image_url) ?? []
+  }));
+
+  return {
+    data: processed,
+    page,
+    totalPages
+  };
+};

--- a/src/lib/utils/api/my-life-client.api.ts
+++ b/src/lib/utils/api/my-life-client.api.ts
@@ -29,9 +29,9 @@ export const getLifePostsAll = async ({ page }: { page: number }): Promise<GetLi
 
   const totalPages = count ? Math.ceil(count / postsPerPage) : 1;
 
-  const processed = (MyLifePosts ?? []).map((post: any) => ({
+  const processed = (MyLifePosts ?? []).map((post) => ({
     ...post,
-    image_urls: post.life_post_image_path?.map((img: any) => img.image_url) ?? []
+    image_urls: post.life_post_image_path?.map((img) => img.image_url) ?? []
   }));
 
   return {

--- a/src/types/life-post.ts
+++ b/src/types/life-post.ts
@@ -10,9 +10,15 @@ export interface SoloLifeCardType {
   thumbnail: string; // 대표 이미지 (보통 첫 번째 이미지)
   imageUrls: string[]; // 전체 이미지 목록
   isMission: boolean;
-  tags: string[];
 }
 
 export interface LifePostWithImageUrls extends LifePost {
   image_urls: string[];
+}
+
+//페이지네이션으로 라이프포스트 조회할때 필요한 response 타입
+export interface GetLifePostsResponse {
+  data: LifePostWithImageUrls[];
+  page: number;
+  totalPages: number;
 }


### PR DESCRIPTION
## ✨ feature(#이슈번호): 기능명
 - close #44 

 
 ## 🔎 작업 내용
 
- [x] supabase 에서 지정된 개수(현재 8개) 로 끊어서 페이지네이션으로 데이터 가져오는 API 함수 작성 
- [x] 무한 스크롤 구현 
- [x] 공통 카드 컴포넌트 반영 
- [x] 무한 스크롤 구현 하려고, react-intersection-observer 설치했어요! pnpm i 부탁드려요 🙏 (제가 따로 분리를 못했어요ㅠ)
 
 
 ## 🖼️ 작업 내용 미리보기
 
![chrome-capture-2025-4-7](https://github.com/user-attachments/assets/0f9804cf-cd18-4ca1-a700-937f89bb5ea1)
 
 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 
 Closes #44