### PR TITLE
Refactor/#139 메인 페이지 디자인 반영

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,19 +114,21 @@ body {
   box-shadow: none !important;
 }
 
+/* 스와이프 커스텀 페이지 네이션 */
 .custom-pagination .custom-bullet {
-  width: 0.375rem; /* w-1.5 */
-  height: 0.375rem; /* h-1.5 */
-  border-radius: 9999px; /* rounded-full */
-  border: 1px solid #8d939a; /* border-neutral-400 */
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 9999px;
+  border: 1px solid #8d939a;
   background: transparent;
   cursor: pointer;
 }
 
+/* 스와이프 커스텀 페이지 네이션 액티브 상태 */
 .custom-pagination .custom-bullet-active {
-  width: 1.5rem; /* w-6 */
-  height: 0.375rem; /* h-1.5 */
-  border-radius: 0.75rem; /* rounded-xl */
+  width: 1.5rem;
+  height: 0.375rem;
+  border-radius: 0.75rem;
   border: none;
-  background: #2e3135; /* bg-neutral-800 */
+  background: #2e3135;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -118,7 +118,7 @@ body {
   width: 0.375rem; /* w-1.5 */
   height: 0.375rem; /* h-1.5 */
   border-radius: 9999px; /* rounded-full */
-  border: 1px solid #a1a1aa; /* border-neutral-400 */
+  border: 1px solid #8d939a; /* border-neutral-400 */
   background: transparent;
   cursor: pointer;
 }
@@ -128,5 +128,5 @@ body {
   height: 0.375rem; /* h-1.5 */
   border-radius: 0.75rem; /* rounded-xl */
   border: none;
-  background: #1f2937; /* bg-neutral-800 */
+  background: #2e3135; /* bg-neutral-800 */
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,8 +9,8 @@ const HomePage = async () => {
   return (
     <>
       <MainBannerSwiper />
-      <section className="mt-14 w-[1200px] space-y-[26px]">
-        <strong className="justify-start self-stretch text-xl font-semibold leading-7 text-zinc-800">
+      <section className="mt-[46px] flex w-[1200px] flex-col gap-[26px]">
+        <strong className="text-secondary-grey-900 justify-start self-stretch text-xl font-semibold leading-7">
           YOLA 챌린지
         </strong>
         <div className="flex items-center justify-between self-stretch">
@@ -19,8 +19,8 @@ const HomePage = async () => {
           ))}
         </div>
       </section>
-      <hr className="mx-auto mt-[57px] w-[1200px] outline-neutral-300" />
-      <section className="mx-auto mb-[71px] mt-[61px] flex w-[1200px] items-center justify-between self-stretch">
+      <hr className="outline-secondary-grey-200 mx-auto mt-[57px] w-[1200px]" />
+      <section className="mx-auto mb-[73px] mt-[61px] flex w-[1200px] items-center justify-between self-stretch">
         <RandomMissionSection />
         <div className="h-60 w-0 origin-top-left outline outline-1 outline-offset-[-0.50px] outline-gray-200" />
         <GonggamPreviewSection />

--- a/src/components/features/home/main-banner.tsx
+++ b/src/components/features/home/main-banner.tsx
@@ -7,15 +7,15 @@ const MainBanner = ({ title, text, color }: Banner) => {
   return (
     <div
       className={clsx(
-        'relative h-60 w-[1280px] overflow-hidden',
-        color === 'orange' && 'bg-amber-300',
-        color === 'blue' && 'bg-[#D8EFF7]',
-        color === 'red' && 'bg-[#FFBFA9]'
+        'relative h-[238px] w-[1280px] overflow-hidden',
+        color === 'orange' && 'bg-banner-orange',
+        color === 'blue' && 'bg-banner-blue',
+        color === 'red' && 'bg-banner-red'
       )}
     >
       <div className="absolute left-[40px] top-[135px] inline-flex w-[455px] flex-col items-start justify-start gap-2.5">
-        <strong className="justify-start self-stretch text-3xl font-bold text-neutral-800">{title}</strong>
-        <p className="justify-start self-stretch text-base font-normal leading-snug text-neutral-800">{text}</p>
+        <strong className="text-secondary-grey-900 justify-start self-stretch text-3xl font-bold">{title}</strong>
+        <p className="text-secondary-grey-900 justify-start self-stretch text-base leading-snug">{text}</p>
       </div>
       <div className="absolute left-[1001px] top-[48px] h-44 w-32 overflow-hidden">
         <Image priority src={MAIN_CHARACTER_URL} alt="메인 배너 캐릭터" width={124} height={167.96} />

--- a/src/components/features/home/main-checklist-card.tsx
+++ b/src/components/features/home/main-checklist-card.tsx
@@ -6,12 +6,12 @@ const CheckListCard = ({ checkListType }: { checkListType: string }) => {
   return (
     <Link
       href={`${PATH.CHECKLIST}/${checkListType}`}
-      className="relative h-56 w-56 overflow-hidden rounded-[30px] bg-white outline outline-1 outline-gray-300"
+      className="outline-secondary-grey-300 relative h-[221px] w-[221px] overflow-hidden rounded-[30px] bg-white outline outline-1"
     >
-      <p className="absolute left-[16px] top-[19px] w-[70px] justify-start leading-snug text-zinc-800">
+      <p className="text-secondary-grey-900 absolute left-[16px] top-[19px] justify-start leading-snug">
         {checkListType} <br /> 체크리스트
       </p>
-      <div className="absolute left-0 top-[79px] h-36 w-56 overflow-hidden bg-gray-50">
+      <div className="absolute left-0 top-[79px] h-36 w-56 overflow-hidden">
         <Image
           src={`/images/${checkListType}.svg`}
           alt={`${checkListType} 체크리스트 이미지`}

--- a/src/components/features/home/main-gonggam-item-container.tsx
+++ b/src/components/features/home/main-gonggam-item-container.tsx
@@ -11,7 +11,7 @@ const ItemContainer = ({ children, postId, category }: ContainerProps) => {
   return (
     <Link
       href={`${PATH.GONGGAM}/${category}/${postId}`}
-      className="inline-flex h-[67px] items-end justify-between self-stretch border-b border-stone-300 py-3"
+      className="border-secondary-grey-400 inline-flex h-[67px] items-end justify-between self-stretch border-b py-3"
     >
       {children}
     </Link>

--- a/src/components/features/home/main-gonggam-item-container.tsx
+++ b/src/components/features/home/main-gonggam-item-container.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
-import { PATH } from '@/constants/page-path';
 import type { Children } from '@/types/children';
+import { PATH } from '@/constants/page-path';
 
 interface ContainerProps extends Children {
   postId: number;
@@ -11,7 +11,7 @@ const ItemContainer = ({ children, postId, category }: ContainerProps) => {
   return (
     <Link
       href={`${PATH.GONGGAM}/${category}/${postId}`}
-      className="inline-flex items-end justify-between self-stretch border-b border-stone-300 py-3"
+      className="inline-flex h-[67px] items-end justify-between self-stretch border-b border-stone-300 py-3"
     >
       {children}
     </Link>

--- a/src/components/features/home/main-gonggam-item-contents-container.tsx
+++ b/src/components/features/home/main-gonggam-item-contents-container.tsx
@@ -1,7 +1,7 @@
-import { Children } from '@/types/children';
+import type { Children } from '@/types/children';
 
 const ContentsContainer = ({ children }: Children) => {
-  return <div className="flex flex-col items-start justify-start gap-1 self-stretch">{children}</div>;
+  return <div className="flex w-[341px] flex-col items-start justify-start gap-1 self-stretch">{children}</div>;
 };
 
 export default ContentsContainer;

--- a/src/components/features/home/main-gonggam-item.tsx
+++ b/src/components/features/home/main-gonggam-item.tsx
@@ -13,8 +13,10 @@ const GonggamItem = ({ post }: ItemProps) => {
   return (
     <ItemContainer postId={id} category={category}>
       <ContentsContainer>
-        <h2 className="justify-start self-stretch text-sm">{title}</h2>
-        <p className="w-80 justify-start overflow-hidden text-ellipsis whitespace-nowrap text-xs">{content}</p>
+        <p className="w-full justify-start self-stretch text-base leading-snug">{title}</p>
+        <p className="min-h-[17px] w-full justify-start overflow-hidden text-ellipsis whitespace-nowrap text-xs leading-none">
+          {content}
+        </p>
       </ContentsContainer>
       <ReactionBox likes={likes.length} comments={comments.length} />
     </ItemContainer>

--- a/src/components/features/home/main-gonggam-preview-title-section.tsx
+++ b/src/components/features/home/main-gonggam-preview-title-section.tsx
@@ -4,8 +4,9 @@ import { PATH } from '@/constants/page-path';
 const TitleSection = () => {
   return (
     <div className="inline-flex items-center justify-between self-stretch">
-      <strong className="justify-start text-xl font-semibold leading-7 text-zinc-800">1인가구 공감 게시판</strong>
-
+      <strong className="text-secondary-grey-900 justify-start text-xl font-semibold leading-7">
+        1인가구 공감 게시판
+      </strong>
       <Link href={PATH.GONGGAM} className="text-secondary-grey-900 flex h-[28px] items-center text-sm font-normal">
         <p className="h-[17px] w-[49px]">전체보기</p>
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/features/home/main-gonggam-preview-title-section.tsx
+++ b/src/components/features/home/main-gonggam-preview-title-section.tsx
@@ -6,8 +6,11 @@ const TitleSection = () => {
     <div className="inline-flex items-center justify-between self-stretch">
       <strong className="justify-start text-xl font-semibold leading-7 text-zinc-800">1인가구 공감 게시판</strong>
 
-      <Link href={PATH.GONGGAM} className="justify-start text-sm font-normal text-zinc-800">
-        전체보기 &gt;
+      <Link href={PATH.GONGGAM} className="text-secondary-grey-900 flex h-[28px] items-center text-sm font-normal">
+        <p className="h-[17px] w-[49px]">전체보기</p>
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M8 9L11 6L8 3" stroke="#2E3135" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
       </Link>
     </div>
   );

--- a/src/components/features/home/main-random-mission-button.tsx
+++ b/src/components/features/home/main-random-mission-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { CustomButton } from '@/components/ui/custom-button';
 import RandomMissionModal from '@/components/features/modals/random-mission';
 import type { Tables } from '@/types/supabase';
 
@@ -14,15 +15,9 @@ const MissionButton = ({ isLogin, missionData }: ButtonProps) => {
   const clickModal = () => setShowModal(!showModal);
   return (
     <>
-      <button
-        data-priority="Secondary"
-        data-size="Medium"
-        data-status="Default"
-        onClick={clickModal}
-        className="gap-2.5 self-stretch rounded-xl bg-white px-4 py-2.5 text-center leading-snug outline outline-1"
-      >
+      <CustomButton variant="outline" onClick={clickModal}>
         미션뽑기
-      </button>
+      </CustomButton>
       {showModal && (
         <RandomMissionModal
           showModal={showModal}

--- a/src/components/features/home/main-random-mission.tsx
+++ b/src/components/features/home/main-random-mission.tsx
@@ -1,9 +1,9 @@
 import { getUserSessionState } from '@/lib/utils/api/auth.api';
+import { getMissionsData } from '@/lib/utils/api/missions.api';
 import ImageSection from '@/components/features/home/main-random-mission-image';
 import MissionButton from '@/components/features/home/main-random-mission-button';
 import RandomMissionContainer from '@/components/features/home/main-random-mission-container';
 import TitleSection from '@/components/features/home/main-random-title';
-import { getMissionsData } from '@/lib/utils/api/missions.api';
 
 const RandomMissionSection = async () => {
   const { isLogin } = await getUserSessionState();
@@ -11,7 +11,7 @@ const RandomMissionSection = async () => {
 
   return (
     <RandomMissionContainer>
-      <div className="flex h-full w-60 flex-col gap-[71px]">
+      <div className="flex h-full w-[230px] flex-col gap-[71px]">
         <TitleSection />
         <MissionButton isLogin={isLogin} missionData={missionData} />
       </div>


### PR DESCRIPTION
## ✨ refactor(#139): 메인페이지 디자인 반영
 

 
 ## 🔎 작업 내용
 
 - 시안 반영해서 디자인 살짝 수정했습니다.
 - 1-2 픽셀 정도 살짝 달라진 정도입니다!
 - 헤더 수정사항이 아직 반영 안되어서, 배너 윗 부분이 살짝 잘려있어요.
 

 
 ## 🖼️ 작업 내용 미리보기
 
<img width="1424" alt="스크린샷 2025-04-15 20 27 09" src="https://github.com/user-attachments/assets/226f2160-d37d-4d30-9226-abca0d791a60" />

 

 
 ## 💬 리뷰 요구사항
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 놓친 부분 있다면 말씀해주세요...🙇🏻‍♀️
 
 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 
 Closes #139


**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```