### PR TITLE
Feature/#172 gonggam detail 중간PR(조회수, 디자인적용)

### DIFF
--- a/src/app/gonggam/(post)/[category]/[postId]/layout.tsx
+++ b/src/app/gonggam/(post)/[category]/[postId]/layout.tsx
@@ -2,8 +2,8 @@ import type { Children } from '@/types/children';
 
 const PostDetailLayout = ({ children }: Children) => {
   return (
-    <div className="w-full p-8 pt-0">
-      <div className="mt-6">{children}</div>
+    <div className="w-full">
+      <div>{children}</div>
     </div>
   );
 };

--- a/src/app/gonggam/(post)/[category]/[postId]/page.tsx
+++ b/src/app/gonggam/(post)/[category]/[postId]/page.tsx
@@ -65,7 +65,7 @@ const GonggamPostDetail = async ({ params: { category, postId } }: GonggamPostDe
 
       {/* 본문 영역 */}
       <section className="prose prose-sm sm:prose lg:prose-lg mb-[46px] mt-[40px] max-w-none justify-start text-[16px] text-secondary-grey-800">
-        <p>{content}</p>
+        <p className="whitespace-pre-wrap">{content}</p>
       </section>
 
       {/* 좋아요 영역 */}

--- a/src/app/gonggam/(post)/[category]/[postId]/page.tsx
+++ b/src/app/gonggam/(post)/[category]/[postId]/page.tsx
@@ -1,10 +1,12 @@
 import GonggamCommentForm from '@/components/features/gonggam/gonggam-comment-form';
 import GonggamCommentList from '@/components/features/gonggam/gonggam-comment-list';
+import GonggamDetailViewCount from '@/components/features/gonggam/gonggam-detail-view-count';
 import GonggamImageSwiper from '@/components/features/gonggam/gonggam-image-swiper';
 import GonggamLikes from '@/components/features/gonggam/gonggam-likes';
 import GonggamMyPostDropdown from '@/components/features/gonggam/gonggam-my-post-dropdown';
 import { DEFAULT_AVATAR_URL } from '@/constants/default-image-url';
 import { getUserProfile } from '@/lib/utils/api/auth.api';
+import { getViewCount } from '@/lib/utils/api/gonggam-board.api';
 import { getGonggamPostDetail } from '@/lib/utils/api/gonggam-detail.api';
 import { getKoreanDateTime } from '@/lib/utils/utc-to-kst';
 import { Dot } from 'lucide-react';
@@ -20,6 +22,7 @@ interface GonggamPostDetailProps {
 const GonggamPostDetail = async ({ params: { category, postId } }: GonggamPostDetailProps) => {
   const userData = await getUserProfile();
   const { title, content, created_at, updated_at, profile, images, tags } = await getGonggamPostDetail(postId);
+  const viewCount = await getViewCount(String(postId));
 
   const displayDate = updated_at ?? created_at;
 
@@ -44,6 +47,9 @@ const GonggamPostDetail = async ({ params: { category, postId } }: GonggamPostDe
             <span>{profile.nickname}</span>
             <Dot size={12} />
             <time dateTime={displayDate}>{getKoreanDateTime(displayDate)}</time>
+            <Dot size={12} />
+            {/* 디테일 뷰카운트 */}
+            <GonggamDetailViewCount postId={String(postId)} initCount={viewCount} />
           </div>
           {/* {userId === profile.id && <GonggamMyPostDropdown />} */}
           {userData?.id === profile.id && <GonggamMyPostDropdown postId={postId} />}

--- a/src/app/gonggam/(post)/[category]/[postId]/page.tsx
+++ b/src/app/gonggam/(post)/[category]/[postId]/page.tsx
@@ -27,7 +27,7 @@ const GonggamPostDetail = async ({ params: { category, postId } }: GonggamPostDe
   const displayDate = updated_at ?? created_at;
 
   return (
-    <article>
+    <article className="px-[40px]">
       {/* 게시글 헤더 */}
       <header className="mt-[64px]">
         <h1 className="mb-[12px] justify-start self-stretch text-xl font-semibold leading-7 text-secondary-grey-900">
@@ -64,7 +64,7 @@ const GonggamPostDetail = async ({ params: { category, postId } }: GonggamPostDe
       )}
 
       {/* 본문 영역 */}
-      <section className="prose prose-sm sm:prose lg:prose-lg mb-[46px] max-w-none justify-start text-base text-secondary-grey-800">
+      <section className="prose prose-sm sm:prose lg:prose-lg mb-[46px] mt-[40px] max-w-none justify-start text-[16px] text-secondary-grey-800">
         <p>{content}</p>
       </section>
 
@@ -72,9 +72,12 @@ const GonggamPostDetail = async ({ params: { category, postId } }: GonggamPostDe
       <GonggamLikes postId={postId} userId={userData?.id} />
 
       {/* 태그 영역 */}
-      <ul className="mb-6 mt-4 flex flex-wrap gap-2 text-sm text-muted-foreground">
+      <ul className="mt-[46px] flex flex-wrap gap-[8px] border-b pb-[38px] text-[12px]">
         {tags?.map((tag) => (
-          <li key={tag} className="rounded-md border border-gray-300 bg-muted px-2 py-1 text-xs text-gray-600">
+          <li
+            key={tag}
+            className="border-black/12 rounded-[4px] border bg-secondary-grey-150 px-2 py-1 text-[12px] text-secondary-grey-900"
+          >
             # {tag}
           </li>
         ))}

--- a/src/components/features/gonggam/gonggam-board-meta.tsx
+++ b/src/components/features/gonggam/gonggam-board-meta.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { getViewCountByClient } from '@/lib/utils/api/gonggam-board-client.api';
+import { Eye, Heart, MessageSquare } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface GonggamBoardMetaProps {
+  likeCnt: number;
+  commentCnt: number;
+  postId: string;
+}
+
+const GonggamBoardMeta = ({ likeCnt, commentCnt, postId }: GonggamBoardMetaProps) => {
+  const [viewCount, setViewCount] = useState<number>(0);
+
+  useEffect(() => {
+    const fetchViewCount = async () => {
+      try {
+        const cnt = await getViewCountByClient(postId);
+        setViewCount(cnt);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchViewCount();
+  }, [postId]);
+
+  return (
+    <footer className="mb-[11px] flex gap-[12px] self-stretch">
+      <div className="flex items-center gap-[3px] overflow-hidden truncate text-[12px] font-normal leading-normal text-secondary-grey-900">
+        <Heart size={12} /> {likeCnt}
+      </div>
+      <div className="flex items-center gap-[3px] overflow-hidden truncate text-[12px] font-normal leading-normal text-secondary-grey-900">
+        <MessageSquare size={12} /> {commentCnt}
+      </div>
+      <div className="flex items-center gap-[3px] overflow-hidden truncate text-[12px] font-normal leading-normal text-secondary-grey-900">
+        <Eye size={12} /> {viewCount}
+      </div>
+    </footer>
+  );
+};
+
+export default GonggamBoardMeta;

--- a/src/components/features/gonggam/gonggam-board-meta.tsx
+++ b/src/components/features/gonggam/gonggam-board-meta.tsx
@@ -1,30 +1,14 @@
 'use client';
 
-import { getViewCountByClient } from '@/lib/utils/api/gonggam-board-client.api';
 import { Eye, Heart, MessageSquare } from 'lucide-react';
-import { useEffect, useState } from 'react';
 
 interface GonggamBoardMetaProps {
   likeCnt: number;
   commentCnt: number;
-  postId: string;
+  viewCount: number;
 }
 
-const GonggamBoardMeta = ({ likeCnt, commentCnt, postId }: GonggamBoardMetaProps) => {
-  const [viewCount, setViewCount] = useState<number>(0);
-
-  useEffect(() => {
-    const fetchViewCount = async () => {
-      try {
-        const cnt = await getViewCountByClient(postId);
-        setViewCount(cnt);
-      } catch (error) {
-        console.error(error);
-      }
-    };
-    fetchViewCount();
-  }, [postId]);
-
+const GonggamBoardMeta = ({ likeCnt, commentCnt, viewCount }: GonggamBoardMetaProps) => {
   return (
     <footer className="mb-[11px] flex gap-[12px] self-stretch">
       <div className="flex items-center gap-[3px] overflow-hidden truncate text-[12px] font-normal leading-normal text-secondary-grey-900">

--- a/src/components/features/gonggam/gonggam-comment-form.tsx
+++ b/src/components/features/gonggam/gonggam-comment-form.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { Button } from '@/components/ui/button';
+import { CustomButton } from '@/components/ui/custom-button';
 import { Input } from '@/components/ui/input';
 import { DEFAULT_AVATAR_URL } from '@/constants/default-image-url';
 import { MSG } from '@/constants/messages';
@@ -34,9 +35,9 @@ const GonggamCommentForm = ({ postId, isLogin, profileImage = DEFAULT_AVATAR_URL
   };
 
   return (
-    <div>
-      <form className="flex items-center gap-2" onSubmit={handleSubmit}>
-        <div className="relative h-[40px] w-[40px] overflow-hidden rounded-full">
+    <div className="border-t py-[24px]">
+      <form className="flex items-center gap-[16px]" onSubmit={handleSubmit}>
+        <div className="border-black/12 relative h-[40px] w-[40px] overflow-hidden rounded-full border">
           <Image src={profileImage} alt="profile" fill sizes="40px" className="object-cover" />
         </div>
         <Input
@@ -45,10 +46,11 @@ const GonggamCommentForm = ({ postId, isLogin, profileImage = DEFAULT_AVATAR_URL
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}
           disabled={!isLogin}
+          className="font-base flex h-[46px] flex-1 items-center gap-[10px] rounded-[8px] bg-secondary-grey-150 px-[10px] py-[16px] leading-[140%]"
         />
-        <Button type="submit" disabled={isUploading || !isLogin}>
+        <CustomButton type="submit" size="comment-submit" disabled={isUploading || !isLogin}>
           등록하기
-        </Button>
+        </CustomButton>
       </form>
     </div>
   );

--- a/src/components/features/gonggam/gonggam-comment-list.tsx
+++ b/src/components/features/gonggam/gonggam-comment-list.tsx
@@ -12,12 +12,12 @@ const GonggamCommentList = ({ postId }: { postId: number }) => {
   if (isCommentsPending) return null;
 
   return (
-    <div className="mt-8">
-      <h2 className="mb-4 text-base font-medium">댓글 {comments.length}개</h2>
+    <div className="mb-[44px] mt-[24px]">
+      <h2 className="mb-[14px] text-base font-medium">댓글 {comments.length}개</h2>
       {comments.map((comment) => (
-        <div key={comment.id} className="mb-6 flex items-start gap-2 border-b pb-6 text-sm">
+        <div key={comment.id} className="flex items-start gap-[16px] py-[12px] text-sm">
           {/* 프로필 이미지 */}
-          <div className="relative h-[40px] w-[40px] shrink-0 overflow-hidden rounded-full">
+          <div className="border-black/12 relative h-[40px] w-[40px] shrink-0 overflow-hidden rounded-full border">
             <Image
               src={comment.writer.profileImage || DEFAULT_AVATAR_URL}
               alt={`${comment.writer.nickname}`}
@@ -28,12 +28,14 @@ const GonggamCommentList = ({ postId }: { postId: number }) => {
           </div>
 
           {/* 닉네임, 시간, 텍스트 */}
-          <div>
-            <div className="flex items-center gap-1">
-              <p className="font-mono">{comment.writer.nickname ?? '알 수 없음'}</p>
-              <span className="text-xs text-gray-400">{formatRelativeDate(comment.created_at)}</span>
+          <div className="flex flex-col gap-[4px]">
+            <div className="flex items-center gap-[8px]">
+              <p className="text-[16px] font-semibold leading-[1.4]">{comment.writer.nickname ?? '알 수 없음'}</p>
+              <span className="text-[16px] font-normal text-secondary-grey-700">
+                {formatRelativeDate(comment.created_at)}
+              </span>
             </div>
-            <p className="mt-1 text-xs text-muted-foreground">{comment.comment}</p>
+            <p className="text-[16px] font-normal leading-[1.4]">{comment.comment}</p>
           </div>
         </div>
       ))}

--- a/src/components/features/gonggam/gonggam-detail-view-count.tsx
+++ b/src/components/features/gonggam/gonggam-detail-view-count.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useViewCount } from '@/lib/hooks/use-view-count';
+import { Eye } from 'lucide-react';
+
+interface GonggamDetailViewCountProps {
+  postId: string;
+  initCount: number;
+}
+
+const GonggamDetailViewCount = ({ postId, initCount }: GonggamDetailViewCountProps) => {
+  const viewCount = useViewCount(postId, initCount);
+  return (
+    <div className="text-secondary-gray-800 flex items-center gap-[3px] text-[16px] font-normal leading-[1.4]">
+      <Eye size={14} />
+      {viewCount}
+    </div>
+  );
+};
+
+export default GonggamDetailViewCount;

--- a/src/components/features/gonggam/gonggam-post-card.tsx
+++ b/src/components/features/gonggam/gonggam-post-card.tsx
@@ -40,7 +40,7 @@ const GonggamPostCard = async ({ post }: GonggamPostCardProps) => {
         <div className="mb-[13px] mt-[4px] flex flex-col items-start gap-1 self-stretch">
           <h3 className="flex-1 text-[14px] font-normal leading-[140%] text-secondary-grey-900">{post.title}</h3>
           <p className="overflow-hidden truncate text-[12px] font-normal leading-[140%] text-secondary-grey-900">
-            {post.content}
+            {post.content.length > 100 ? `${post.content.slice(0, 100)}...` : post.content}
           </p>
         </div>
         {/* 좋아요/댓글/조회수 */}

--- a/src/components/features/gonggam/gonggam-post-card.tsx
+++ b/src/components/features/gonggam/gonggam-post-card.tsx
@@ -2,8 +2,9 @@ import Image from 'next/image';
 import { DEFAULT_LIFE_IMAGE_URL } from '@/constants/default-image-url';
 import { getPostImagesByPostId, getPostMetaByPostId, getWriterProfile } from '@/lib/utils/api/gonggam-board.api';
 import { formatRelativeDate } from '@/lib/utils/date-format';
-import { Dot, Eye, Heart, MessageSquare } from 'lucide-react';
+import { Dot } from 'lucide-react';
 import type { GonggamPost } from '@/types/gonggam';
+import GonggamBoardMeta from '@/components/features/gonggam/gonggam-board-meta';
 
 interface GonggamPostCardProps {
   post: GonggamPost;
@@ -29,7 +30,6 @@ const GonggamPostCard = async ({ post }: GonggamPostCardProps) => {
           <Dot size={12} className="translate-y-[-2px]" />
           <time dateTime={post.created_at}>{formatRelativeDate(post.created_at)}</time>
         </div>
-
         {/* 텍스트 영역 */}
         <div className="mb-[13px] mt-[4px] flex flex-col items-start gap-1 self-stretch">
           <h3 className="flex-1 text-[14px] font-normal leading-[140%] text-secondary-grey-900">{post.title}</h3>
@@ -37,19 +37,8 @@ const GonggamPostCard = async ({ post }: GonggamPostCardProps) => {
             {post.content}
           </p>
         </div>
-
-        {/* 좋아요/댓글 */}
-        <footer className="mb-[11px] flex gap-[12px] self-stretch">
-          <div className="flex items-center gap-[3px] overflow-hidden truncate text-[12px] font-normal leading-normal text-secondary-grey-900">
-            <Heart size={12} /> {likeCnt}
-          </div>
-          <div className="flex items-center gap-[3px] overflow-hidden truncate text-[12px] font-normal leading-normal text-secondary-grey-900">
-            <MessageSquare size={12} /> {commentCnt}
-          </div>
-          <div className="flex items-center gap-[3px] overflow-hidden truncate text-[12px] font-normal leading-normal text-secondary-grey-900">
-            <Eye size={12} /> 0
-          </div>
-        </footer>
+        {/* 좋아요/댓글/조회수 */}
+        <GonggamBoardMeta likeCnt={likeCnt} commentCnt={commentCnt} postId={String(post.id)} />
       </section>
 
       {/* 이미지 */}

--- a/src/components/features/gonggam/gonggam-post-card.tsx
+++ b/src/components/features/gonggam/gonggam-post-card.tsx
@@ -1,6 +1,11 @@
 import Image from 'next/image';
 import { DEFAULT_LIFE_IMAGE_URL } from '@/constants/default-image-url';
-import { getPostImagesByPostId, getPostMetaByPostId, getWriterProfile } from '@/lib/utils/api/gonggam-board.api';
+import {
+  getPostImagesByPostId,
+  getPostMetaByPostId,
+  getViewCount,
+  getWriterProfile
+} from '@/lib/utils/api/gonggam-board.api';
 import { formatRelativeDate } from '@/lib/utils/date-format';
 import { Dot } from 'lucide-react';
 import type { GonggamPost } from '@/types/gonggam';
@@ -20,6 +25,7 @@ const GonggamPostCard = async ({ post }: GonggamPostCardProps) => {
 
   /** like, comments 불러오기 */
   const { likeCnt, commentCnt } = await getPostMetaByPostId(post.id);
+  const viewCount = await getViewCount(String(post.id));
 
   return (
     <article className="flex max-w-[1200px] items-start justify-between gap-[10px] border-b border-secondary-grey-200 px-[10px] py-[12px]">
@@ -38,7 +44,7 @@ const GonggamPostCard = async ({ post }: GonggamPostCardProps) => {
           </p>
         </div>
         {/* 좋아요/댓글/조회수 */}
-        <GonggamBoardMeta likeCnt={likeCnt} commentCnt={commentCnt} postId={String(post.id)} />
+        <GonggamBoardMeta likeCnt={likeCnt} commentCnt={commentCnt} viewCount={viewCount} />
       </section>
 
       {/* 이미지 */}

--- a/src/components/ui/custom-button.tsx
+++ b/src/components/ui/custom-button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
       size: {
         default: 'w-[230px] py-[10px] rounded-xl font-semibold',
         'error-page': 'w-[240px] py-[10px] rounded-xl font-semibold',
-        'comment-submit': 'w-[80px] py-[12px] rounded-lg',
+        'comment-submit': 'min-w-[80px] h-[46px] p-[12px] rounded-[8px]',
         'gonggam-write': 'w-[100px] h-[38px]  rounded-lg',
         'auth-submit': 'w-[360px] py-[10px] rounded-lg',
         login: 'px-[12px] py-[8px] min-w-[66px] rounded-lg',

--- a/src/lib/utils/api/gonggam-board-client.api.ts
+++ b/src/lib/utils/api/gonggam-board-client.api.ts
@@ -1,0 +1,19 @@
+import { TABLE } from '@/constants/supabase-tables-name';
+import { supabase } from '../supabase/supabase-client';
+
+/**
+ * 선택한 게시글의 조회수를 클라이언트 컴포넌트에서 조회하기 위한 api 함수입니다.
+ * @param { string } postId - 선택한 게시글의 id
+ * @returns { number } - 선택한 게시글의 조회수
+ */
+export const getViewCountByClient = async (postId: string): Promise<number> => {
+  const { data, error } = await supabase
+    .from(TABLE.GONGGAM_POSTS)
+    .select('view_count')
+    .eq('id', Number(postId))
+    .single();
+
+  if (error) throw error;
+
+  return data.view_count;
+};

--- a/src/lib/utils/supabase/middleware.ts
+++ b/src/lib/utils/supabase/middleware.ts
@@ -30,7 +30,8 @@ export async function updateSession(request: NextRequest) {
     API.GOOGLE_LOGIN,
     API.KAKAO_LOGIN,
     API.SOCIAL_LOGIN_CALL_BACK,
-    API.DUPLICATE
+    API.DUPLICATE,
+    API.VIEW_COUNT
   ];
 
   // 루트 경로는 정확한 매칭, /gonggam/[category]/[postId]는 정규식으로 체크, 나머지는 startsWith


### PR DESCRIPTION
## ✨ feature(#이슈번호): 기능명
 - #172 

 
 ## 🔎 작업 내용
 
 - 게시글 조회수 넣기 : 서버에서 불러와서 보여주는 식을 채택.
   - CSR로 하면 처음에 0이었다가 깜빡거리는 게 불편해서 일단 서버처리 해두었습니다.
   - 이왕 깜빡거릴거라면 다른 댓글, 좋아요도 같이 깜빡거리는 게 나을 것 같아서 추후 결정할 사항으로 공유합니다.
 - 게시글 상세 디자인 시안 적용
 

 
 ## 🖼️ 작업 내용 미리보기
 
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/fccec474-47d5-40d6-9e28-6548a7a9d108" />

<img width="1178" alt="image" src="https://github.com/user-attachments/assets/916ee612-1c7c-4a51-b162-102fcb492d83" />
조회수 추가됨.

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/a2f08ca2-4f18-42c8-89ac-0d3bb965c44c" />


댓글은 이렇게.
 
 ## 💬 리뷰 요구사항
 
 - 댓글 디자인이 들어갔지만, 박스쉐도우는 현재 불가능.

 
<img width="692" alt="image" src="https://github.com/user-attachments/assets/1be50882-0dac-46b2-b516-9edec6ea7054" />

하지만 제가 박스쉐도우를 적용하면
 
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/ca7a53be-0599-465e-a8cd-b86a58b136d3" />

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/92233e7d-81f7-4881-8156-25a047a39e69" />

<img width="1160" alt="image" src="https://github.com/user-attachments/assets/6e7b8030-84ac-484c-8412-8f10a2bbf905" />


어떻게 해도 옆테두리는 사라지지 않아서 일단 상단 border로만 적용하였고,
그에 따른 영향으로 여백이 커보이는 효과를 얻었습니다.

 현재 `border-t`로 작업해두었습니다.
 
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/9f3d460a-85f5-4f16-bf05-30a9c8292a91" />

혹시 위에만 박스 쉐도우를 적용하신 분이 있다면 제게 비법을 전수해주세요.



 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 
 Ref #172

**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```