### PR TITLE
refactor:#194 해쉬태그 입력 오류

### DIFF
--- a/src/components/common/tag-input.tsx
+++ b/src/components/common/tag-input.tsx
@@ -15,15 +15,6 @@ const TagInput = ({ value = [], onChange, maxTags = 6 }: TagInputProps) => {
   const [inputValue, setInputValue] = useState('');
   const [inputVisible, setInputVisible] = useState(false);
   const [shouldShake, setShouldShake] = useState(false);
-  const isComposing = useRef(false);
-
-  const handleCompositionStart = () => {
-    isComposing.current = true;
-  };
-
-  const handleCompositionEnd = () => {
-    isComposing.current = false;
-  };
 
   const triggerShake = () => {
     setShouldShake(true);
@@ -58,12 +49,12 @@ const TagInput = ({ value = [], onChange, maxTags = 6 }: TagInputProps) => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (isComposing.current) return; //한글 조합 중이라면 리턴
-
-    if (e.key === 'Enter' || e.key === ',') {
-      e.preventDefault();
-      const success = addTag(inputValue);
-      if (success) setInputValue('');
+    if (e.nativeEvent.isComposing === false) {
+      if (e.key === 'Enter' || e.key === ',') {
+        e.preventDefault();
+        const success = addTag(inputValue);
+        if (success) setInputValue('');
+      }
     }
   };
 
@@ -107,8 +98,6 @@ const TagInput = ({ value = [], onChange, maxTags = 6 }: TagInputProps) => {
           value={inputValue}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
-          onCompositionStart={handleCompositionStart}
-          onCompositionEnd={handleCompositionEnd}
           placeholder="입력 후 Enter 또는 ,"
           className="min-w-[80px] rounded border border-gray-300 px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-yellow-200"
         />

--- a/src/components/common/tag-input.tsx
+++ b/src/components/common/tag-input.tsx
@@ -15,6 +15,15 @@ const TagInput = ({ value = [], onChange, maxTags = 6 }: TagInputProps) => {
   const [inputValue, setInputValue] = useState('');
   const [inputVisible, setInputVisible] = useState(false);
   const [shouldShake, setShouldShake] = useState(false);
+  const isComposing = useRef(false);
+
+  const handleCompositionStart = () => {
+    isComposing.current = true;
+  };
+
+  const handleCompositionEnd = () => {
+    isComposing.current = false;
+  };
 
   const triggerShake = () => {
     setShouldShake(true);
@@ -49,6 +58,8 @@ const TagInput = ({ value = [], onChange, maxTags = 6 }: TagInputProps) => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (isComposing.current) return; //한글 조합 중이라면 리턴
+
     if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
       const success = addTag(inputValue);
@@ -96,6 +107,8 @@ const TagInput = ({ value = [], onChange, maxTags = 6 }: TagInputProps) => {
           value={inputValue}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
           placeholder="입력 후 Enter 또는 ,"
           className="min-w-[80px] rounded border border-gray-300 px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-yellow-200"
         />


### PR DESCRIPTION
## ✨ feature(#이슈번호): #194 
 

 
 ## 🔎 작업 내용
  - 맥북에서 한글로 해쉬태그 입력 시 두번 입력되는 오류 해결
  - 한글 입력에서 **조합 중 입력 상태(Composing)**를 고려하지 않고 Enter 키 이벤트를 처리할 때 흔히 발생하는 현상으로,
     특히 맥북에서는 한글을 입력할 때 조합 중인 글자가 있을 때도 keydown 이벤트가 먼저 발생하기 때문에, 
     아직 조합이 끝나지 않은 상태에서 엔터를 누르면 글자가 쪼개져서 처리된다고 합니다
 - 한글 조합 중인지 이벤트의 상태를 추적하고, 조합 중이 아닐 때 엔터를 처리하는 것으로 해결하였습니다
 

 
 ## 🖼️ 작업 내용 미리보기
- 적용 전
https://github.com/user-attachments/assets/59641c2e-4b08-431e-9f42-573cfe784bd4


- 적용 후
https://github.com/user-attachments/assets/3447e461-0b9d-4a2a-b83c-0fb7141f6fa0


 
 ## 💬 리뷰 요구사항
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
 
 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 Closes #194 


**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```