### PR TITLE
refactor:#208 모바일 디자인 반영 및 뒤로가기 적용

### DIFF
--- a/src/components/features/modals/delete-confirm.tsx
+++ b/src/components/features/modals/delete-confirm.tsx
@@ -6,39 +6,71 @@ import { CustomButton } from '@/components/ui/custom-button';
  * Step 1. 모달을 호출할 파일에 이 코드를 추가해주세요
  * const [showModal, setShowModal] = useState(false);
  *
- * Step 2. 삭제버튼이 있는 부분에 이 코드를 넣어주세요
+ * Step 2. 삭제(뒤로가기)버튼이 있는 부분에 이 코드를 넣어주세요
  *  onClick={() => setShowModal(!showModal)}
  *
- * Step 3. 버튼이 있는 코드 바깥에(맵을 돌리고 있다면 맵 바깥에) 이 코드를 추가해주세요
+ * Step 3(삭제) 버튼이 있는 코드 바깥에(맵을 돌리고 있다면 맵 바깥에) 이 코드를 추가해주세요
  * 삭제 대상이 댓글이라면 isItPost={false}를 넣어주세요
  * {showModal && <DeleteConfirmModal clickModal={() => setShowModal(false)} handleDelete={handleDelete} isItPost={true} />}
+ *
+ * Step 3(뒤로가기) return 문 가장 하위에 이 코드를 추가해주세요
+ * {showModal && <DeleteConfirmModal clickModal={() => setShowModal(false)} handleDelete={handleDelete} isItPost={true} isItBack={true} />}
  */
 const DeleteConfirmModal = ({
   clickModal,
   handleDelete,
-  isItPost
+  isItPost,
+  isItBack = false
 }: {
   clickModal: () => void;
   handleDelete: () => void;
   isItPost: boolean;
+  isItBack?: boolean;
 }) => {
   const modal = (
     <div
-      onClick={clickModal} // 배경 클릭하면 모달 나가기
+      onClick={clickModal}
       className="fixed inset-0 z-[60] flex min-h-screen items-center justify-center bg-gray-500/50"
     >
       <div
-        onClick={(e) => e.stopPropagation()} // 모달 안을 클릭 했을 때 나가는 것 막음
-        className="relative h-[267px] w-[508px] rounded-2xl bg-white px-[139px] pb-[44px] pt-[60px] shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        className="relative w-[343px] rounded-2xl bg-white px-[32px] py-[32px] shadow-2xl md:h-[268px] md:w-[508px] md:px-[140px] md:py-[44px] md:pt-[60px]"
       >
-        <X onClick={clickModal} className="absolute right-6 top-6 cursor-pointer text-secondary-grey-900" />
-        <div className="mb-[63px] flex flex-col justify-start gap-2.5 self-stretch text-center leading-relaxed text-secondary-grey-900">
-          <strong className="h-[26px] text-xl font-semibold">{isItPost ? `글` : `댓글`}을 삭제합니다.</strong>
-          <p className="h-[22px] text-base font-normal">정말 삭제하시겠습니까?</p>
+        <X
+          onClick={clickModal}
+          className="absolute right-6 top-6 hidden cursor-pointer text-secondary-grey-900 md:block"
+        />
+
+        <div className="mb-[40px] flex flex-col items-center text-center leading-relaxed text-secondary-grey-900 md:mb-[63px]">
+          {isItBack ? (
+            <>
+              <strong className="text-xl font-semibold">글 작성을 취소합니다.</strong>
+              <p className="text-md mt-2 h-[22px] font-normal">작성 중인 내용은 저장되지 않습니다.</p>
+            </>
+          ) : (
+            <>
+              <strong className="text-xl font-semibold">{isItPost ? `글` : `댓글`}을 삭제합니다.</strong>
+              <p className="text-md mt-2 h-[22px] font-normal">정말 삭제하시겠습니까?</p>
+            </>
+          )}
         </div>
-        <CustomButton onClick={handleDelete} type="button" className="mx-auto">
-          삭제하기
-        </CustomButton>
+
+        {/* 모바일: 취소 + 삭제 버튼 */}
+        <div className="flex justify-center gap-4 md:hidden">
+          <CustomButton variant={'outline'} onClick={clickModal} type="button" className="w-[135px]">
+            {isItBack ? '뒤로가기' : '취소하기'}
+          </CustomButton>
+          <CustomButton onClick={handleDelete} type="button" className="w-[135px]">
+            {isItBack ? '작성 취소' : '삭제하기'}
+          </CustomButton>
+        </div>
+
+        {/* 데스크탑: 삭제 버튼만 */}
+        <div className="hidden justify-center md:flex">
+          <CustomButton onClick={handleDelete} type="button" className="w-[230px]">
+            {isItBack ? '작성 취소' : '삭제하기'}
+          </CustomButton>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## ✨ feature(#이슈번호): #208
 

 
 ## 🔎 작업 내용
 
 - 모바일 디자인을 반영했습니다
 - 글 작성 페이지에서 뒤로가기를 클릭했을 때도 사용할 수 있도록 변경하였습니다
 - 용도가 추가됨에 따라 delete-confirm-modal에서 confirm-modal로 이름 변경을 할 것입니다
 - 이름 변경, 설치, import문 변경은 따로 브랜치를 파서 작업하겠습니다 
 

 
 ## 🖼️ 작업 내용 미리보기
전과 동일

 
 ## 💬 리뷰 요구사항
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
 
 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 
 Closes #208 


**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```