### PR TITLE
Refactor/#218 lint fix

### DIFF
--- a/src/components/features/auth-form/auth-form-field.tsx
+++ b/src/components/features/auth-form/auth-form-field.tsx
@@ -49,7 +49,8 @@ const AuthFormField = <T extends FieldValues>({
       setErrorMessage(null);
     }
     if (fieldName === AUTH.CHECK_PASSWORD) {
-      isValid ? setSuccessMessage(SUCCESS.PASSWORD) : setSuccessMessage(null);
+      const message = isValid ? SUCCESS.PASSWORD : null;
+      setSuccessMessage(message);
     }
   }, [fieldValue, setDuplicateCheck, fieldName, isValid]);
 

--- a/src/components/features/mypage/edit-profile-form-nickname-field.tsx
+++ b/src/components/features/mypage/edit-profile-form-nickname-field.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { clsx } from 'clsx';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useFormContext, UseFormReturn } from 'react-hook-form';
 import DuplicateCheckMessage from '@/components/features/auth-form/duplicate-check-message';
@@ -70,7 +69,7 @@ const NicknameField = ({ form, setDuplicateCheck, initNickname }: FieldProps) =>
           <div className="relative ml-[42px] mr-[8px]">
             <FormControl>
               <Input
-                className={clsx('h-[37px] w-[269px] rounded border-secondary-grey-400 p-2.5')}
+                className="h-[37px] w-[269px] rounded border-secondary-grey-400 p-2.5"
                 placeholder={PLACEHOLDER.NICKNAME}
                 type="text"
                 {...field}

--- a/src/components/features/mypage/edit-profile-form-nickname-field.tsx
+++ b/src/components/features/mypage/edit-profile-form-nickname-field.tsx
@@ -13,7 +13,7 @@ import { fetchDuplicateCheck } from '@/lib/utils/api/auth/auth-client.api';
 import type { EditFormData } from '@/types/auth-form';
 
 interface FieldProps {
-  form: UseFormReturn<EditFormData, any, undefined>;
+  form: UseFormReturn<EditFormData>;
   setDuplicateCheck: Dispatch<SetStateAction<boolean>>;
   initNickname: string;
 }
@@ -32,7 +32,7 @@ const NicknameField = ({ form, setDuplicateCheck, initNickname }: FieldProps) =>
     setErrorMessage(null);
 
     if (initNickname === getValues(AUTH.NICKNAME)) setDuplicateCheck(true); // 기존 닉네임과 같으면 중복검사 pass
-  }, [nicknameValue, setDuplicateCheck]);
+  }, [getValues, initNickname, nicknameValue, setDuplicateCheck]);
 
   // -------------------------------------------------
   const handleDuplicateCheck = async () => {
@@ -66,20 +66,11 @@ const NicknameField = ({ form, setDuplicateCheck, initNickname }: FieldProps) =>
       name={AUTH.NICKNAME}
       render={({ field }) => (
         <FormItem className="flex h-10 items-center justify-start self-stretch">
-          <FormLabel
-            className={clsx(
-              'justify-start text-lg font-normal',
-              errorMessage ? 'text-destructive' : 'text-secondary-grey-900'
-            )}
-          >
-            {LABEL.NICKNAME}
-          </FormLabel>
-          <div className="relative">
+          <FormLabel className="justify-start text-lg font-normal text-secondary-grey-900">{LABEL.NICKNAME}</FormLabel>
+          <div className="relative ml-[42px] mr-[8px]">
             <FormControl>
               <Input
-                className={clsx(
-                  'ml-[42px] mr-[8px] flex h-[37px] w-[269px] items-center justify-start gap-2.5 rounded border-secondary-grey-400 p-2.5'
-                )}
+                className={clsx('h-[37px] w-[269px] rounded border-secondary-grey-400 p-2.5')}
                 placeholder={PLACEHOLDER.NICKNAME}
                 type="text"
                 {...field}


### PR DESCRIPTION
## ✨ refactor(#218): lint 에러 / 경고 해결
 

 
 ## 🔎 작업 내용
 
 - auth form filed 삼항연산자 때문에 오류가 났던 건데, 삼항연산자로 할당한 값을 setValue에 넣어주는 방식으로 변경했습니다.
 - nickname field는 useEffect 의존성배열 때문에 오류가 났던 거라 추가해줬습니다.
 - any 타입은 삭제했습니다!
 - 중복검사 할 때 오류 메시지가 왼쪽에 치우쳐져 보였는데 해당 부분 스타일 조정했습니다.
 

 
 ## 🖼️ 작업 내용 미리보기
 
😘

 
 ## 💬 리뷰 요구사항
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
 
 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 
 Closes #218


**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```