### PR TITLE
Refactor/#225 checklist mobile 디자인 반영(swiper, QA)

### DIFF
--- a/src/components/features/checklist/checklist-client.tsx
+++ b/src/components/features/checklist/checklist-client.tsx
@@ -34,7 +34,7 @@ const ChecklistClient = ({ decodedMission, userId, userLevel, progress, missionL
   };
 
   return (
-    <section className="w-full pt-[59px]">
+    <section className="w-full pt-[32px] md:pt-[59px]">
       <div className="flex w-full flex-col gap-[34px] pl-[37px] pr-[39px]">
         <h1 className="whitespace-nowrap text-[20px] font-semibold">{decodedMission} 체크리스트</h1>
         <ChecklistProgress progress={progress} userLevel={userLevel as EnumLevel} />

--- a/src/components/features/checklist/checklist-client.tsx
+++ b/src/components/features/checklist/checklist-client.tsx
@@ -36,7 +36,7 @@ const ChecklistClient = ({ decodedMission, userId, userLevel, progress, missionL
   return (
     <section className="w-full pl-[37px] pr-[39px] pt-[59px]">
       <div className="flex w-full flex-col gap-[34px]">
-        <h1 className="whitespace-nowrap text-2xl font-bold">{decodedMission} 체크리스트</h1>
+        <h1 className="whitespace-nowrap text-[20px] font-semibold">{decodedMission} 체크리스트</h1>
         <ChecklistProgress progress={progress} userLevel={userLevel as EnumLevel} />
       </div>
       <MissionListClient

--- a/src/components/features/checklist/checklist-client.tsx
+++ b/src/components/features/checklist/checklist-client.tsx
@@ -34,8 +34,8 @@ const ChecklistClient = ({ decodedMission, userId, userLevel, progress, missionL
   };
 
   return (
-    <section className="w-full pl-[37px] pr-[39px] pt-[59px]">
-      <div className="flex w-full flex-col gap-[34px]">
+    <section className="w-full pt-[59px]">
+      <div className="flex w-full flex-col gap-[34px] pl-[37px] pr-[39px]">
         <h1 className="whitespace-nowrap text-[20px] font-semibold">{decodedMission} 체크리스트</h1>
         <ChecklistProgress progress={progress} userLevel={userLevel as EnumLevel} />
       </div>

--- a/src/components/features/checklist/checklist-mission-swiper.tsx
+++ b/src/components/features/checklist/checklist-mission-swiper.tsx
@@ -24,7 +24,7 @@ const ChecklistMissionSwiper = ({ missionList, userId, onCompletedClick }: Check
         slidesPerView={'auto'}
         coverflowEffect={{
           rotate: 0,
-          stretch: -20,
+          stretch: -50,
           depth: 100,
           modifier: 1,
           slideShadows: false

--- a/src/components/features/checklist/checklist-mission-swiper.tsx
+++ b/src/components/features/checklist/checklist-mission-swiper.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { EffectCoverflow, Pagination } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import MissionCardWrapper from '@/components/features/checklist/mission-card-wrapper';
+import 'swiper/css';
+import 'swiper/css/effect-coverflow';
+import 'swiper/css/pagination';
+import type { MissionWithStatus } from '@/types/checklist';
+
+interface ChecklistMissionSwiperProps {
+  missionList: MissionWithStatus[];
+  userId?: string;
+  onCompletedClick?: (missionId: number) => void;
+}
+
+const ChecklistMissionSwiper = ({ missionList, userId, onCompletedClick }: ChecklistMissionSwiperProps) => {
+  return (
+    <div className="overflow-visible px-4">
+      <Swiper
+        effect={'coverflow'}
+        grabCursor={true}
+        centeredSlides={true}
+        slidesPerView={'auto'}
+        coverflowEffect={{
+          rotate: 0,
+          stretch: -20,
+          depth: 100,
+          modifier: 1,
+          slideShadows: false
+        }}
+        pagination={{
+          clickable: true,
+          el: '.custom-pagination',
+          bulletClass: 'custom-bullet',
+          bulletActiveClass: 'custom-bullet-active'
+        }}
+        modules={[EffectCoverflow, Pagination]}
+        className="mySwiper"
+      >
+        {missionList.map((mission) => (
+          <SwiperSlide key={mission.id} className="!w-[221px] shrink-0">
+            <MissionCardWrapper mission={mission} userId={userId} onCompletedClick={onCompletedClick} />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+      <div className="custom-pagination mt-[29px] inline-flex items-center justify-center gap-2" />
+    </div>
+  );
+};
+
+export default ChecklistMissionSwiper;

--- a/src/components/features/checklist/checklist-mission-swiper.tsx
+++ b/src/components/features/checklist/checklist-mission-swiper.tsx
@@ -16,7 +16,7 @@ interface ChecklistMissionSwiperProps {
 
 const ChecklistMissionSwiper = ({ missionList, userId, onCompletedClick }: ChecklistMissionSwiperProps) => {
   return (
-    <div className="overflow-visible px-4">
+    <div className="overflow-visible">
       <Swiper
         effect={'coverflow'}
         grabCursor={true}

--- a/src/components/features/checklist/checklist-progress.tsx
+++ b/src/components/features/checklist/checklist-progress.tsx
@@ -28,7 +28,7 @@ const ChecklistProgress = ({ progress, userLevel }: ChecklistProgressProps) => {
           {/* 진행도 바 */}
           <div className="flex h-3 w-full overflow-hidden rounded-md">
             {progressBar.map((bar, idx) => {
-              if (bar.type === 'full') return <div key={idx} className="flex-1 bg-black" />;
+              if (bar.type === 'full') return <div key={idx} className="flex-1 bg-secondary-grey-900" />;
 
               if (bar.type === 'partial') {
                 return (
@@ -69,13 +69,15 @@ const ChecklistProgress = ({ progress, userLevel }: ChecklistProgressProps) => {
                 >
                   <div className="relative flex items-center">
                     <span
-                      className={`inline-flex items-center gap-1 ${
+                      className={clsx(
+                        'inline-flex items-center gap-1 rounded-[12px]',
                         isCurrent
-                          ? 'rounded-lg bg-secondary-grey-900 px-3 py-2.5 text-[16px] text-white'
-                          : 'rounded-[12px] border border-secondary-grey-400 p-[12px] text-[12px] font-normal text-secondary-grey-800 md:px-3 md:py-2.5'
-                      }`}
+                          ? 'h-[37px] w-[63px] bg-secondary-grey-900 px-2 py-[10px] text-[12px] text-white md:h-[42px] md:w-[79px] md:px-3 md:py-2.5 md:text-[16px]'
+                          : 'h-[38px] w-[38px] border border-secondary-grey-400 p-[12px] text-[12px] font-normal text-secondary-grey-800 md:h-[41px] md:w-[71px] md:px-3 md:py-2.5',
+                        !isCurrent && 'justify-center md:justify-start'
+                      )}
                     >
-                      <span className={clsx('md:inline', !isCurrent && 'hidden md:inline')}>{label}</span>
+                      <span className={clsx('md:inline', !isCurrent && 'hidden')}>{label}</span>
                       {isUnlocked ? (
                         <Unlock className="h-[16px] w-[16px] shrink-0" />
                       ) : (

--- a/src/components/features/checklist/checklist-progress.tsx
+++ b/src/components/features/checklist/checklist-progress.tsx
@@ -1,3 +1,4 @@
+import { clsx } from 'clsx';
 import { Lock, Unlock } from 'lucide-react';
 import type { EnumLevel } from '@/types/supabase-const';
 
@@ -71,10 +72,10 @@ const ChecklistProgress = ({ progress, userLevel }: ChecklistProgressProps) => {
                       className={`inline-flex items-center gap-1 ${
                         isCurrent
                           ? 'rounded-lg bg-secondary-grey-900 px-3 py-2.5 text-[16px] text-white'
-                          : 'rounded-[12px] border border-secondary-grey-400 px-3 py-2.5 text-[12px] font-normal text-secondary-grey-800'
+                          : 'rounded-[12px] border border-secondary-grey-400 p-[12px] text-[12px] font-normal text-secondary-grey-800 md:px-3 md:py-2.5'
                       }`}
                     >
-                      {label}
+                      <span className={clsx('md:inline', !isCurrent && 'hidden md:inline')}>{label}</span>
                       {isUnlocked ? (
                         <Unlock className="h-[16px] w-[16px] shrink-0" />
                       ) : (

--- a/src/components/features/checklist/mission-card-wrapper.tsx
+++ b/src/components/features/checklist/mission-card-wrapper.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import MissionCard from '@/components/features/checklist/mission-card';
+import { FAIL } from '@/constants/messages';
+import { PATH } from '@/constants/page-path';
+import { toastAlert } from '@/lib/utils/toast';
+import type { MissionWithStatus } from '@/types/checklist';
+
+interface MissionCardWrapperProps {
+  mission: MissionWithStatus;
+  userId?: string;
+  onCompletedClick?: (missionId: number) => void;
+}
+
+const MissionCardWrapper = ({ mission, userId, onCompletedClick }: MissionCardWrapperProps) => {
+  const router = useRouter();
+  const isCompleted = mission.completed;
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!userId) {
+      e.preventDefault();
+      toastAlert(FAIL.NEED_LOGIN, 'destructive');
+      router.push(PATH.LOGIN);
+    } else if (isCompleted && onCompletedClick) {
+      e.preventDefault();
+      onCompletedClick(mission.id);
+    }
+  };
+
+  const href = !isCompleted && userId ? `${PATH.LIFE_POST}?mission_id=${mission.id}` : '#';
+
+  return (
+    <Link
+      href={href}
+      onClick={handleClick}
+      className="flex h-[248px] w-[221px] flex-col items-start rounded-[20px] border border-secondary-grey-300 bg-white"
+    >
+      <MissionCard mission={mission} isCompleted={isCompleted} />
+    </Link>
+  );
+};
+
+export default MissionCardWrapper;

--- a/src/components/features/checklist/mission-card-wrapper.tsx
+++ b/src/components/features/checklist/mission-card-wrapper.tsx
@@ -35,7 +35,7 @@ const MissionCardWrapper = ({ mission, userId, onCompletedClick }: MissionCardWr
     <Link
       href={href}
       onClick={handleClick}
-      className="flex h-[248px] w-[221px] flex-col items-start rounded-[20px] border border-secondary-grey-300 bg-white"
+      className="flex h-[280px] w-[250px] flex-col items-start rounded-[20px] border border-secondary-grey-300 bg-white md:h-[248px] md:w-[221px]"
     >
       <MissionCard mission={mission} isCompleted={isCompleted} />
     </Link>

--- a/src/components/features/checklist/mission-card.tsx
+++ b/src/components/features/checklist/mission-card.tsx
@@ -11,8 +11,8 @@ interface MissionCardProps {
 const MissionCard = ({ mission, isCompleted }: MissionCardProps) => {
   return (
     <>
-      <strong className="flex w-[221px] items-start gap-[10px] px-[20px] py-[20px] pb-0 pt-[20px]">
-        <span className="flex-1 grow basis-0 text-[16px] font-semibold leading-[1.4] text-primary-orange-900">
+      <strong className="flex w-[250px] items-start gap-[10px] px-[20px] py-[20px] pb-0 pt-[20px] md:w-[221px]">
+        <span className="flex-1 grow basis-0 text-[18px] font-semibold leading-[1.4] text-primary-orange-900 md:text-[16px]">
           {mission.content}
         </span>
       </strong>
@@ -20,11 +20,11 @@ const MissionCard = ({ mission, isCompleted }: MissionCardProps) => {
         <Image
           src={isCompleted ? DONE : UNDO}
           alt={isCompleted ? '완료' : '진행 전'}
-          className="h-[93px] w-[93px] flex-shrink-0"
+          className="h-[105px] w-[105px] flex-shrink-0 md:h-[93px] md:w-[93px]"
         />
       </figure>
-      <div className="flex h-[45px] items-center justify-center gap-[10px] self-stretch rounded-b-[20px] bg-primary-orange-200">
-        <span className="flex-1 grow basis-0 text-center text-[14px] leading-[1.4]">
+      <div className="flex h-[50px] items-center justify-center gap-[10px] self-stretch rounded-b-[20px] bg-primary-orange-200 md:h-[45px]">
+        <span className="flex-1 grow basis-0 text-center text-[16px] leading-[1.4] md:text-[14px]">
           {isCompleted ? '인증글 보기' : '인증하기'}
         </span>
       </div>

--- a/src/components/features/checklist/mission-card.tsx
+++ b/src/components/features/checklist/mission-card.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image';
+import type { MissionWithStatus } from '@/types/checklist';
+import DONE from '@images/images/checklist-done.svg';
+import UNDO from '@images/images/checklist-undo.svg';
+
+interface MissionCardProps {
+  mission: MissionWithStatus;
+  isCompleted: boolean;
+}
+
+const MissionCard = ({ mission, isCompleted }: MissionCardProps) => {
+  return (
+    <>
+      <strong className="flex w-[221px] items-start gap-[10px] px-[20px] py-[20px] pb-0 pt-[20px]">
+        <span className="flex-1 grow basis-0 text-[16px] font-semibold leading-[1.4] text-primary-orange-900">
+          {mission.content}
+        </span>
+      </strong>
+      <figure className="flex flex-1 items-center justify-center gap-[10px] self-stretch px-[10px]">
+        <Image
+          src={isCompleted ? DONE : UNDO}
+          alt={isCompleted ? '완료' : '진행 전'}
+          className="h-[93px] w-[93px] flex-shrink-0"
+        />
+      </figure>
+      <div className="flex h-[45px] items-center justify-center gap-[10px] self-stretch rounded-b-[20px] bg-primary-orange-200">
+        <span className="flex-1 grow basis-0 text-center text-[14px] leading-[1.4]">
+          {isCompleted ? '인증글 보기' : '인증하기'}
+        </span>
+      </div>
+    </>
+  );
+};
+
+export default MissionCard;

--- a/src/components/features/checklist/mission-list-client.tsx
+++ b/src/components/features/checklist/mission-list-client.tsx
@@ -1,15 +1,9 @@
 'use client';
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { Dispatch, SetStateAction } from 'react';
-import { FAIL } from '@/constants/messages';
-import { PATH } from '@/constants/page-path';
-import { toastAlert } from '@/lib/utils/toast';
+import ChecklistMissionSwiper from '@/components/features/checklist/checklist-mission-swiper';
+import MissionCardWrapper from '@/components/features/checklist/mission-card-wrapper';
 import type { MissionWithStatus } from '@/types/checklist';
-import DONE from '@images/images/checklist-done.svg';
-import UNDO from '@images/images/checklist-undo.svg';
 
 interface ClientMissionListProps {
   setSelectedMissionId: Dispatch<SetStateAction<number | null>>;
@@ -18,59 +12,20 @@ interface ClientMissionListProps {
 }
 
 const MissionListClient = ({ setSelectedMissionId, missionList, userId }: ClientMissionListProps) => {
-  const router = useRouter();
-
-  const handleMissionClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (!userId) {
-      e.preventDefault();
-      toastAlert(FAIL.NEED_LOGIN, 'destructive');
-      router.push(PATH.LOGIN);
-    }
-  };
-
-  const handleCompletedMissionClick = (missionId: number) => {
-    setSelectedMissionId(missionId);
-  };
-
   return (
-    <ul className="mt-[129px] flex w-full max-w-[1200px] items-center gap-[24px]">
-      {missionList.map((mission) => {
-        const isCompleted = mission.completed;
-        const handleClick = isCompleted
-          ? () => handleCompletedMissionClick(mission.id)
-          : !userId
-            ? handleMissionClick
-            : undefined;
+    <div>
+      <section className="mb-[36px] mt-[92px] block w-full md:hidden">
+        <ChecklistMissionSwiper missionList={missionList} userId={userId} onCompletedClick={setSelectedMissionId} />
+      </section>
 
-        return (
-          <li key={mission.id} className="">
-            <Link
-              href={!isCompleted && userId ? `${PATH.LIFE_POST}?mission_id=${mission.id}` : '#'}
-              onClick={handleClick}
-              className="flex h-[248px] w-[221px] flex-col items-start rounded-[20px] border border-secondary-grey-300 bg-white"
-            >
-              <strong className="flex w-[221px] items-start gap-[10px] px-[20px] py-[20px] pb-0 pt-[20px]">
-                <span className="flex-1 grow basis-0 text-[16px] font-semibold leading-[1.4] text-primary-orange-900">
-                  {mission.content}
-                </span>
-              </strong>
-              <figure className="flex flex-1 items-center justify-center gap-[10px] self-stretch px-[10px]">
-                <Image
-                  src={isCompleted ? DONE : UNDO}
-                  alt={isCompleted ? '완료' : '진행 전'}
-                  className="h-[93px] w-[93px] flex-shrink-0"
-                />
-              </figure>
-              <div className="flex h-[45px] items-center justify-center gap-[10px] self-stretch rounded-b-[20px] bg-primary-orange-200">
-                <span className="flex-1 grow basis-0 text-center text-[14px] leading-[1.4]">
-                  {isCompleted ? '인증글 보기' : '인증하기'}
-                </span>
-              </div>
-            </Link>
+      <ul className="mt-[129px] hidden w-full max-w-[1200px] items-center gap-[24px] md:flex">
+        {missionList.map((mission) => (
+          <li key={mission.id}>
+            <MissionCardWrapper mission={mission} userId={userId} onCompletedClick={setSelectedMissionId} />
           </li>
-        );
-      })}
-    </ul>
+        ))}
+      </ul>
+    </div>
   );
 };
 

--- a/src/components/features/checklist/mission-list-client.tsx
+++ b/src/components/features/checklist/mission-list-client.tsx
@@ -18,7 +18,7 @@ const MissionListClient = ({ setSelectedMissionId, missionList, userId }: Client
         <ChecklistMissionSwiper missionList={missionList} userId={userId} onCompletedClick={setSelectedMissionId} />
       </section>
 
-      <ul className="mt-[129px] hidden w-full max-w-[1200px] items-center gap-[24px] md:flex">
+      <ul className="mt-[129px] hidden w-full max-w-[1200px] items-center gap-[24px] pl-[37px] pr-[39px] md:flex">
         {missionList.map((mission) => (
           <li key={mission.id}>
             <MissionCardWrapper mission={mission} userId={userId} onCompletedClick={setSelectedMissionId} />


### PR DESCRIPTION
## ✨ feature(#이슈번호): 기능명
 - close #225

 
 ## 🔎 작업 내용
 
 - swiper 적용을 비롯, 체크리스트 페이지 반응형 디자인
 - 모바일 디자인 반영에 따른 체크리스트 페이지 구조 리팩토링
 - QA 반영 : 체크리스트 화면 제목 폰트 수정(size/bold)
 
 ## 🖼️ 작업 내용 미리보기

![화면 기록 2025-04-23 오후 4](https://github.com/user-attachments/assets/5a88b12c-6a13-4062-aaa4-feb2b2c3df82)

- 2단계 이상부터는 기존 진행도 말풍선이랑 위치가 붙어있는데, 데스크탑에서 단계 말풍선 위치를 오른쪽 맨 끝으로 주는 작업이 더럽게(?) 되어서 수정이 벅찹니다.. 현재 겹치지는 않게 딱 맞닿아있는 구조가 최선인지라 일단 이렇게 1차 머지 해두고 싶습니다 ㅜ

![스크린샷 2025-04-23 오후 4 41 06](https://github.com/user-attachments/assets/a990552d-61b5-4027-9178-86dfdbc01f36)

- 디자인 시안 기준으로 여백적용하였고, 14Pro Max 처럼 화면이 커지면 아래 여백이 생깁니다.

![스크린샷 2025-04-23 오후 4 39 12](https://github.com/user-attachments/assets/6c2ce875-bc0d-4605-ac92-530b49891ebe)

 ## 💬 리뷰 요구사항

- 할 수 있는 데까진 해보았는데,, 일단 체크리스트 디자인은 이 정도를 1차로 머지해두고 추후 개선해보려 합니다.
  - 추후 개선이 필요한 스코프는 아래와 같습니다.
  - 단계 말풍선(자물쇠) 위치 조정 / 모바일에서 Progress Bar의 스타일 변경 / 그에 따른 진행여부를 Progress Bar 상단에 표시
- 혹시 이것만큼은 지금 당장 적용해야 한다! 하는 디자인 요소가 있다면 말씀 부탁드립니다.

 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 
 Closes #225


**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```