### PR TITLE
Refactor/#249 auth page mobile styling

### DIFF
--- a/src/components/features/auth-form/auth-content.tsx
+++ b/src/components/features/auth-form/auth-content.tsx
@@ -5,7 +5,7 @@ interface ContentProps {
 
 const AuthContent = ({ title, form }: ContentProps) => {
   return (
-    <div className="mb-[121px] mt-12 w-full justify-items-center px-4 md:mb-[75px] md:mt-[60px] md:px-0">
+    <div className="mb-[76px] mt-12 w-full justify-items-center px-4 md:mb-[75px] md:mt-[60px] md:px-0">
       <h1 className="justify-start text-center text-xl font-semibold leading-relaxed text-secondary-grey-900">
         {title}
       </h1>

--- a/src/components/features/auth-form/auth-content.tsx
+++ b/src/components/features/auth-form/auth-content.tsx
@@ -5,7 +5,7 @@ interface ContentProps {
 
 const AuthContent = ({ title, form }: ContentProps) => {
   return (
-    <div className="mt-[60px] w-full justify-items-center">
+    <div className="mb-[121px] mt-12 w-full justify-items-center px-4 md:mb-[75px] md:mt-[60px] md:px-0">
       <h1 className="justify-start text-center text-xl font-semibold leading-relaxed text-secondary-grey-900">
         {title}
       </h1>

--- a/src/components/features/auth-form/login-form-button.tsx
+++ b/src/components/features/auth-form/login-form-button.tsx
@@ -33,16 +33,16 @@ const AuthFormButton = ({ isValid, isLoginPending }: AuthFormButtonProps) => {
           disabled={!isValid || isPending || isLoginPending}
           type="submit"
           size="auth-submit"
-          className="h-[42px]"
+          className="h-[42px] w-full"
         >
           {!isPending && !isLoginPending ? '이메일로 로그인' : '로그인 중...'}
         </CustomButton>
-        <CustomButton asChild size="auth-submit" variant="outline" className="h-[42px]">
+        <CustomButton asChild size="auth-submit" variant="outline" className="h-[42px] w-full">
           <Link href={PATH.SIGNUP}>회원가입</Link>
         </CustomButton>
       </div>
-      <div className="relative mb-[23px] h-[78px] border-b border-t-0 border-secondary-grey-600">
-        <p className="absolute left-[120px] top-[69px] justify-start bg-white px-[26px] text-sm font-normal leading-tight text-secondary-grey-600">
+      <div className="relative mb-[21.5px] h-[50px] border-b border-t-0 border-secondary-grey-600 md:mb-[23px] md:h-[78px]">
+        <p className="absolute left-[113px] top-[41px] justify-start bg-white px-[26px] text-sm font-normal leading-tight text-secondary-grey-600 md:left-[120px] md:top-[69px]">
           간편 로그인
         </p>
       </div>

--- a/src/components/features/auth-form/login-form.tsx
+++ b/src/components/features/auth-form/login-form.tsx
@@ -52,7 +52,7 @@ const LoginForm = () => {
 
   return (
     <Form {...form}>
-      <form className="mt-[37px] w-[360px]" action={handleFormAction}>
+      <form className="mt-[28px] w-full max-w-[360px] md:mt-[37px]" action={handleFormAction}>
         <div className="mb-[28px] flex flex-col gap-[17px]">
           {loginFieldData.map((data, index) => (
             <FormField

--- a/src/components/features/auth-form/signup-form-button.tsx
+++ b/src/components/features/auth-form/signup-form-button.tsx
@@ -5,11 +5,11 @@ import type { AuthFormButtonProps } from '@/types/auth-form';
 
 const SignupFormButton = ({ isValid, isSignupPending }: AuthFormButtonProps) => {
   return (
-    <div className="mt-[51px] flex flex-col gap-3">
-      <CustomButton disabled={!isValid || isSignupPending} type="submit" size="auth-submit">
+    <div className="mt-[53px] flex flex-col gap-3">
+      <CustomButton disabled={!isValid || isSignupPending} type="submit" size="auth-submit" className="w-full">
         {!isSignupPending ? '가입하기' : '회원등록 중...'}
       </CustomButton>
-      <CustomButton asChild variant="outline" size="auth-submit" className="h-[42px]">
+      <CustomButton asChild variant="outline" size="auth-submit" className="h-[42px] w-full">
         <Link href={PATH.LOGIN}>뒤로가기</Link>
       </CustomButton>
     </div>

--- a/src/components/features/auth-form/signup-form.tsx
+++ b/src/components/features/auth-form/signup-form.tsx
@@ -78,7 +78,10 @@ const SignupForm = () => {
 
   return (
     <Form {...form}>
-      <form className="mt-10 w-[365px] space-y-8" action={handleFormAction}>
+      <form
+        className="mt-[42px] flex w-full max-w-[365px] flex-col gap-[29px] md:mt-[35px] md:gap-[27px]"
+        action={handleFormAction}
+      >
         {signupFieldData.map((data, index) => (
           <FormField
             key={index}


### PR DESCRIPTION
## ✨ refactor(#249): 로그인 / 회원가입 페이지 모바일 시안 반영
 

 
 ## 🔎 작업 내용
 
 - 모바일 시안 반영했습니다!
 - 시안 반영하면서 웹 시안과 다른 부분 아주 살짝 수정했습니다.
 

 
 ## 🖼️ 작업 내용 미리보기
 
<img width="497" alt="스크린샷 2025-04-24 02 50 04" src="https://github.com/user-attachments/assets/264f3e04-6b51-4446-9281-691db26f90b7" />

 
<img width="460" alt="스크린샷 2025-04-24 02 50 23" src="https://github.com/user-attachments/assets/aa20f6cf-023f-4672-8a40-841a20b28137" />


 
 ## 💬 리뷰 요구사항
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
 
 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 
 Closes #249


**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```

