### PR TITLE
Refactor/#251 error page mobile styling

### DIFF
--- a/src/components/common/error-block.tsx
+++ b/src/components/common/error-block.tsx
@@ -22,7 +22,7 @@ const ErrorBlock = ({ errorMessage, image }: ErrorBlockProps) => {
   };
 
   return (
-    <section className="inline-flex h-[calc(100vh-150px-250px)] flex-col items-center justify-center justify-items-center gap-10">
+    <section className="inline-flex h-[calc(100vh-150px-157px)] flex-col items-center justify-center justify-items-center gap-10 md:h-[calc(100vh-150px-250px)]">
       <div className="flex flex-col">
         <Image src={image} alt="에러페이지" width={240} height={184} />
         <p className="font-center mb-[20px] mt-[40px] inline-flex items-center justify-center gap-2.5 self-stretch px-2.5 text-center text-base leading-snug text-zinc-800">


### PR DESCRIPTION
## ✨ refactor(#251): 에러 페이지, 컴포넌트 모바일 시안 반영
 

 
 ## 🔎 작업 내용
 
 - 모바일 시안 반영했습니다.
 - 기존 에러 페이지 배치할 때처럼 비율로 계산해서 높이를 지정했습니다!
 

 
 ## 🖼️ 작업 내용 미리보기
 
<img width="476" alt="스크린샷 2025-04-24 03 03 52" src="https://github.com/user-attachments/assets/221996fd-4640-47e4-ab98-dcf7f5235c2d" />

- 피그마 시안과 같은 사이즈: 위 아래 간격이 시안과 같습니다.

<img width="408" alt="스크린샷 2025-04-24 03 04 00" src="https://github.com/user-attachments/assets/926c19ca-a13a-4f6c-abd7-e9d7c3850066" />

- 아이폰 se 기준: 시안과 비교했을 때 헤더와 이미지 시작까지의 간격은 다르지만 배치 비율이 같습니다.

 

 
 ## 💬 리뷰 요구사항
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 > ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
 
 ## ⏰ 예상 리뷰 시간
 
 1분
 
 ### ✔️ 이슈 닫기
 
 Closes #251

**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```