### PR TITLE
Feature/#254 혼자 라이프 필터기능 구현 (전체, 미션, 일기 보기)

### DIFF
--- a/src/app/(auth)/mypage/my-life-list/page.tsx
+++ b/src/app/(auth)/mypage/my-life-list/page.tsx
@@ -2,17 +2,12 @@ import MyLifeListClient from '@/components/features/mypage/my-life-list-client';
 import { getUserProfile } from '@/lib/utils/api/auth/auth.api';
 
 const MyLifeListPage = async () => {
+  //유저 닉네임 조회
   const profile = await getUserProfile();
   if (!profile) throw new Error();
+  const nickname = profile.nickname;
 
-  return (
-    <section className="mt-[20px] px-[16px] md:mt-[72px]">
-      <h2 className="mb-[35px] hidden justify-start self-stretch text-xl font-semibold leading-7 text-secondary-grey-900 md:block">
-        {profile.nickname}님의 혼자 라이프 기록
-      </h2>
-      <MyLifeListClient />
-    </section>
-  );
+  return <MyLifeListClient nickname={nickname} />;
 };
 
 export default MyLifeListPage;

--- a/src/components/features/mypage/my-life-filter.tsx
+++ b/src/components/features/mypage/my-life-filter.tsx
@@ -7,7 +7,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select';
-import type { SortBy } from '@/types/gonggam';
+import type { SortBy } from '@/types/life-post';
 
 interface SelectBoxProps {
   value: string;
@@ -22,11 +22,11 @@ export function SelectBox({ value, onChange }: SelectBoxProps) {
       </SelectTrigger>
       <SelectContent>
         <SelectGroup>
-          <SelectItem value="latest">최신순</SelectItem>
+          <SelectItem value="all">전체 보기</SelectItem>
           <SelectSeparator />
-          <SelectItem value="comments">댓글 많은 순</SelectItem>
+          <SelectItem value="mission">미션 보기</SelectItem>
           <SelectSeparator />
-          <SelectItem value="likes">공감 많은 순</SelectItem>
+          <SelectItem value="diary">일기 보기</SelectItem>
         </SelectGroup>
       </SelectContent>
     </Select>

--- a/src/lib/hooks/queries/use-get-gonggam-posts-infinite-query.ts
+++ b/src/lib/hooks/queries/use-get-gonggam-posts-infinite-query.ts
@@ -11,7 +11,12 @@ const useGetGonggamPostsInfiniteQuery = (sortBy: SortBy) => {
   return useInfiniteQuery<GetMyGonggamPostsResponse>({
     queryKey: [QUERY_KEY.GONGGAM_POSTS_INFINITE, sortBy],
     queryFn: async ({ pageParam = 1 }) => getMyGonggamPostsAll({ page: pageParam as number, sortBy }),
-    getNextPageParam: (lastPage) => (lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined),
+    getNextPageParam: (lastPage) => {
+      if (lastPage.page < lastPage.totalPages) {
+        return lastPage.page + 1;
+      }
+      return undefined;
+    },
     initialPageParam: 1
   });
 };

--- a/src/lib/hooks/queries/use-get-life-posts-infinite-query.ts
+++ b/src/lib/hooks/queries/use-get-life-posts-infinite-query.ts
@@ -1,16 +1,16 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@/constants/query-keys';
 import { getLifePostsAll } from '@/lib/utils/api/mypage/my-life-client.api';
-import type { GetLifePostsResponse } from '@/types/life-post';
+import type { GetLifePostsResponse, SortBy } from '@/types/life-post';
 
 /**
  * @function useGetLifePostsInfiniteQuery
  * @returns - pageParams, pages 을 반환,
  */
-const useGetLifePostsInfiniteQuery = () => {
+const useGetLifePostsInfiniteQuery = (sortBy: SortBy) => {
   return useInfiniteQuery<GetLifePostsResponse>({
-    queryKey: [QUERY_KEY.LIFE_POSTS_INFINITE],
-    queryFn: ({ pageParam }) => getLifePostsAll({ page: pageParam as number }),
+    queryKey: [QUERY_KEY.LIFE_POSTS_INFINITE, sortBy],
+    queryFn: ({ pageParam = 1 }) => getLifePostsAll({ page: pageParam as number, sortBy }),
     getNextPageParam: (lastPage) => {
       if (lastPage.page < lastPage.totalPages) {
         return lastPage.page + 1;

--- a/src/types/life-post.ts
+++ b/src/types/life-post.ts
@@ -21,3 +21,6 @@ export interface GetLifePostsResponse {
   page: number;
   totalPages: number;
 }
+
+//마이페이지 공감 sort 타입 선언
+export type SortBy = 'all' | 'mission' | 'diary';


### PR DESCRIPTION
## ✨ feature(#이슈번호): 기능명
 
- Ref #254 
 
 ## 🔎 작업 내용
 
 - 혼자 라이프 페이지에 전체, 미션, 일기로 구분해서 볼 수 있는 기능 추가
 

 
 ## 🖼️ 작업 내용 미리보기
 
![chrome-capture-2025-4-24 (2)](https://github.com/user-attachments/assets/e3d28897-f00c-4cc7-8d9a-e8ed806b40e4)


 
 ## 💬 리뷰 요구사항
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
[이슈 2가지 공유합니다]
1. 카드 컴포넌트와 내부 이미지가 튀어나가는데, 지금 선제님께서 카드 컴포넌트 리팩토링 중이셔서, 리팩토링 작업이 완료 되면 자연스럽게 해결될 것입니다. (캘린더에서는 w-237, 마이페이지에서는 w-222px 로 되어있어서 발생하는 현상입니다.)
2. 셀렉트 박스 선택 시, 우측에 스크롤바를 사용하는 브라우저 환경의 경우, 스크롤바가 없어졌다가 선택하면 다시 나타나서 화면이 흔들립니다. 여러 방법을 시도했는데 아직 찾지 못해서, 일단 기능 구현이 되어서 PR 올립니다.

이 부분은 계속 찾아보도록 하겠습니다. 참고하셔서 리뷰 부탁드립니다 😅
 
 ## ⏰ 예상 리뷰 시간
 
 5분
 
 ### ✔️ 이슈 닫기
 
 Closes #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝난 경우
 Ref #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝나지 않은 경우


**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```