### PR TITLE
Refactor/#241 마이페이지 카드 컴포넌트 mode 적용

### DIFF
--- a/src/components/common/solo-life-card.tsx
+++ b/src/components/common/solo-life-card.tsx
@@ -42,12 +42,12 @@ const SoloLifeCard = ({
             'rounded-xl'
           )}
         >
-          <Image src={thumbnail} alt="썸네일" fill className="object-cover" />
+          <Image src={thumbnail} alt="썸네일" fill sizes="205" className="object-cover" priority />
         </div>
       </figure>
 
       {/* 콘텐츠 */}
-      <section className="flex flex-1 flex-col justify-between sm:items-start">
+      <section className="flex h-full flex-1 flex-col justify-between sm:items-start">
         {/* 본문 */}
         <p className="line-clamp-1 text-sm font-medium text-secondary-grey-900 sm:line-clamp-none sm:whitespace-pre-line sm:break-words">
           {previewContent}

--- a/src/components/features/mypage/my-life-list-client.tsx
+++ b/src/components/features/mypage/my-life-list-client.tsx
@@ -91,16 +91,13 @@ const MyLifeListClient = ({ nickname }: MyLifeListClientProps) => {
         </div>
       </section>
 
-      {/* <section className="grid gap-[18px] sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"> */}
       <section className="flex flex-wrap gap-[18px]">
         {parsedList.length === 0 ? (
           <NoRecordsBox mode="라이프" />
         ) : (
           <>
             {parsedList.map((post) => (
-              <figure className="min-w-[222px] max-w-[222px]" key={post.id}>
-                <SoloLifeCard {...post} onClick={() => handleClickCard(post.id)} />
-              </figure>
+              <SoloLifeCard {...post} key={post.id} onClick={() => handleClickCard(post.id)} mode="mypage" />
             ))}
             {showModal && (
               <PostDetailModal clickModal={() => setShowModal(false)} showModal={showModal} post={selectedPost} />


### PR DESCRIPTION
## ✨ feature(#이슈번호): 기능명
 - Ref #241 

 
 ## 🔎 작업 내용
 
 - 마이페이지 공통 카드 컴포넌트 리팩토링에 따른 mode 적용 (이제 이미지 안 튀어나갑니다~!)
 

 
 ## 🖼️ 작업 내용 미리보기
 
<img width="336" alt="스크린샷 2025-04-25 오후 5 41 28" src="https://github.com/user-attachments/assets/59e12baa-5b9f-4794-8848-01376647aa89" />

<img width="1133" alt="스크린샷 2025-04-25 오후 6 06 46" src="https://github.com/user-attachments/assets/94d65164-ec35-4343-babe-19f69c6b0def" />



 
 ## ⏰ 예상 리뷰 시간
 
 30초
 
 ### ✔️ 이슈 닫기
 
 Closes #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝난 경우
 Ref #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝나지 않은 경우


**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```