### PR TITLE
Feature/#279 mypage & calendar 스켈레톤 UI

### DIFF
--- a/src/components/features/life/solo-life-list.tsx
+++ b/src/components/features/life/solo-life-list.tsx
@@ -9,6 +9,7 @@ import SoloLifeCard from '@/components/common/solo-life-card';
 import { PostDetailModal } from '@/components/features/modals/calendar-post-detail';
 import { useLifePostsByMonth } from '@/lib/hooks/queries/use-life-posts-by-month';
 import type { LifePostWithImageUrls } from '@/types/life-post';
+import { SoloLifeCardSkeleton, SoloLifeCardSkeletonSection } from '@/components/ui/skeleton';
 interface SoloLifeListProps {
   selectedDate: string;
   setIsEmpty: React.Dispatch<React.SetStateAction<boolean | null>>;
@@ -52,9 +53,7 @@ const SoloLifeList = ({ selectedDate, setIsEmpty }: SoloLifeListProps) => {
     setShowModal(true);
   };
 
-  if (isPending) {
-    return <div>로딩 중...</div>;
-  }
+  if (isPending) return <SoloLifeCardSkeletonSection mode="calendar" />;
 
   if (parsedList.length === 0) {
     return (

--- a/src/components/features/life/solo-life-list.tsx
+++ b/src/components/features/life/solo-life-list.tsx
@@ -7,9 +7,9 @@ import { useEffect, useMemo, useState } from 'react';
 import NoRecordsBox from '@/components/common/no-records-box';
 import SoloLifeCard from '@/components/common/solo-life-card';
 import { PostDetailModal } from '@/components/features/modals/calendar-post-detail';
+import { SoloLifeCardSkeletonSection } from '@/components/ui/skeleton';
 import { useLifePostsByMonth } from '@/lib/hooks/queries/use-life-posts-by-month';
 import type { LifePostWithImageUrls } from '@/types/life-post';
-import { SoloLifeCardSkeleton, SoloLifeCardSkeletonSection } from '@/components/ui/skeleton';
 interface SoloLifeListProps {
   selectedDate: string;
   setIsEmpty: React.Dispatch<React.SetStateAction<boolean | null>>;

--- a/src/components/features/mypage/my-life-list-client.tsx
+++ b/src/components/features/mypage/my-life-list-client.tsx
@@ -7,10 +7,10 @@ import NoRecordsBox from '@/components/common/no-records-box';
 import SoloLifeCard from '@/components/common/solo-life-card';
 import { PostDetailModal } from '@/components/features/modals/calendar-post-detail';
 import { SelectBox } from '@/components/features/mypage/my-life-filter';
+import { SoloLifeCardSkeletonSection } from '@/components/ui/skeleton';
 import { DEFAULT_LIFE_IMAGE_URL } from '@/constants/default-image-url';
 import useGetLifePostsInfiniteQuery from '@/lib/hooks/queries/use-get-life-posts-infinite-query';
 import type { GetLifePostsResponse, LifePostWithImageUrls, SoloLifeCardType, SortBy } from '@/types/life-post';
-import { SoloLifeCardSkeletonSection } from '@/components/ui/skeleton';
 
 interface MyLifeListClientProps {
   nickname: string;

--- a/src/components/features/mypage/my-life-list-client.tsx
+++ b/src/components/features/mypage/my-life-list-client.tsx
@@ -10,6 +10,7 @@ import { SelectBox } from '@/components/features/mypage/my-life-filter';
 import { DEFAULT_LIFE_IMAGE_URL } from '@/constants/default-image-url';
 import useGetLifePostsInfiniteQuery from '@/lib/hooks/queries/use-get-life-posts-infinite-query';
 import type { GetLifePostsResponse, LifePostWithImageUrls, SoloLifeCardType, SortBy } from '@/types/life-post';
+import { SoloLifeCardSkeletonSection } from '@/components/ui/skeleton';
 
 interface MyLifeListClientProps {
   nickname: string;
@@ -55,7 +56,7 @@ const MyLifeListClient = ({ nickname }: MyLifeListClientProps) => {
       })
     ) ?? [];
 
-  if (isPending) return <div className="p-4">로딩 중...</div>;
+  if (isPending) return <SoloLifeCardSkeletonSection mode="mypage" />;
   if (error) throw error;
 
   const handleClickCard = (id: string) => {

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@/lib/utils/utils';
 import { clsx } from 'clsx';
+import { cn } from '@/lib/utils/utils';
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return <div className={cn('animate-pulse rounded-md bg-primary/10', className)} {...props} />;

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -132,11 +132,7 @@ function SoloLifeCardSkeletonSection({ mode }: { mode: 'mypage' | 'calendar' }) 
         <Skeleton className="ml-auto h-[44px] w-[120px]" />
       </section>
 
-      <section className="flex flex-wrap gap-[18px]">
-        {[...Array(4)].map((_, i) => (
-          <SoloLifeCardSkeleton key={i} mode="mypage" />
-        ))}
-      </section>
+      <section className="flex flex-wrap gap-[18px]">{cards}</section>
     </article>
   );
 }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils/utils';
+import { clsx } from 'clsx';
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return <div className={cn('animate-pulse rounded-md bg-primary/10', className)} {...props} />;
@@ -113,4 +114,83 @@ function GonggamSkeletonDetailContent() {
   );
 }
 
-export { Skeleton, SkeletonCard, SkeletonFlatten, GonggamSkeletonSection, GonggamSkeletonDetailContent };
+function SoloLifeCardSkeletonSection({ mode }: { mode: 'mypage' | 'calendar' }) {
+  const cards = [...Array(4)].map((_, i) => <SoloLifeCardSkeleton key={i} mode={mode} />);
+
+  // calendar 모드: 카드들만 렌더링
+  if (mode === 'calendar') {
+    return <section className="flex flex-wrap gap-4">{cards}</section>;
+  }
+
+  // mypage 모드: 제목 + 셀렉트박스 + 카드들 렌더링
+  return (
+    <article className="mt-[20px] px-[16px] md:mt-[72px]">
+      <section className="mb-[12px] flex flex-row items-center justify-between md:mb-[35px]">
+        {/* 데스크탑에서만 보이는 텍스트 */}
+        <Skeleton className="hidden h-[44px] w-[200px] justify-start md:block" />
+        {/* SelectBox 자리 */}
+        <Skeleton className="ml-auto h-[44px] w-[120px]" />
+      </section>
+
+      <section className="flex flex-wrap gap-[18px]">
+        {[...Array(4)].map((_, i) => (
+          <SoloLifeCardSkeleton key={i} mode="mypage" />
+        ))}
+      </section>
+    </article>
+  );
+}
+
+function SoloLifeCardSkeleton({ mode }: { mode: 'mypage' | 'calendar' }) {
+  return (
+    <article
+      className={clsx(
+        'flex w-full cursor-pointer items-start gap-3 rounded-2xl bg-white outline outline-1 outline-offset-[-1px] outline-secondary-grey-300',
+        mode === 'mypage' && 'p-3 sm:h-[322px] sm:w-[222px] sm:flex-col',
+        mode === 'calendar' && 'p-4 sm:h-[337px] sm:w-[237px] sm:flex-col'
+      )}
+    >
+      {/* 이미지 (좌측 or 상단) */}
+      <figure>
+        <Skeleton
+          className={clsx(
+            'relative h-[66px] w-[66px] overflow-hidden',
+            mode === 'mypage' && 'sm:h-[198px] sm:w-[198px]',
+            mode === 'calendar' && 'sm:h-[205px] sm:w-[205px]',
+            // 기본 사이즈 (모바일)
+            'rounded-xl'
+          )}
+        ></Skeleton>
+      </figure>
+
+      {/* 본문 영역 */}
+      <section className="flex h-full flex-1 flex-col justify-between sm:items-start">
+        {/* 미리보기 텍스트 */}
+        <Skeleton className="h-[14px] w-[80%]" />
+
+        {/* 태그 */}
+        <div className="mt-1 flex flex-wrap gap-1">
+          <Skeleton className="h-[24px] w-[40px]" />
+          <Skeleton className="h-[24px] w-[60px]" />
+        </div>
+
+        {/* Footer */}
+        <footer className="mt-1 flex items-center gap-[6px]">
+          <Skeleton className="h-[16px] w-[60px]" />
+          <div className="mt-[1.7px] h-0 w-[9px] rotate-90 outline outline-[0.5px] outline-secondary-grey-400" />
+          <Skeleton className="h-[16px] w-[60px]" />
+        </footer>
+      </section>
+    </article>
+  );
+}
+
+export {
+  Skeleton,
+  SkeletonCard,
+  SkeletonFlatten,
+  GonggamSkeletonSection,
+  GonggamSkeletonDetailContent,
+  SoloLifeCardSkeletonSection,
+  SoloLifeCardSkeleton
+};


### PR DESCRIPTION
## ✨ feature(#이슈번호): 기능명
 
- Ref #279 

 
 ## 🔎 작업 내용
 
 - 마이페이지 혼자라이프 기록 및 캘린더 카드 컴포넌트에 스켈레톤 UI 적용
 

 
 ## 🖼️ 작업 내용 미리보기
 
[웹 버전]
![chrome-capture-2025-4-29 (2)](https://github.com/user-attachments/assets/b0b89d42-fed9-4ac4-b07d-e285eaa3f790)

 [모바일 버전]
<img width="337" alt="스크린샷 2025-04-29 오후 7 12 03" src="https://github.com/user-attachments/assets/1fd894f2-5f60-4ccc-8d73-c061cfe34826" />

 ## 💬 리뷰 요구사항
 
 > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 
캘린더 및 마이페이지 로딩 UI 스켈레톤으로 반영했습니다.
 
 ## ⏰ 예상 리뷰 시간
 
 3분
 

**Reviewer의 의도가 명확하게 전달될 수 있도록, 아래와 같이 P-N 라벨을 리뷰 코멘트 앞에 추가해주세요.**
[예시] `P3) ~ 라인의 컨텍스트는 ~ 이유로 리뷰어 혹은 후속 작업자가 파악하기 힘들 것 같습니다. 주석이 추가되었으면 좋겠습니다.`

```
- P1: 꼭 반영해 주세요 (Request changes)
- P2: 적극적으로 고려해 주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
```